### PR TITLE
Fix wallet cancelled login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed web wallet cancelled login](https://github.com/multiversx/mx-sdk-dapp/pull/598)
 
 ## [[v2.3.0](https://github.com/multiversx/mx-sdk-dapp/pull/596)] - 2023-01-20
 

--- a/src/components/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer.tsx
@@ -39,7 +39,8 @@ import {
   getAccount,
   getLatestNonce,
   newWalletProvider,
-  getLedgerConfiguration
+  getLedgerConfiguration,
+  emptyProvider
 } from 'utils/account';
 import { logout } from 'utils/logout';
 import { parseNavigationParams } from 'utils/parseNavigationParams';
@@ -168,6 +169,8 @@ export function ProviderInitializer() {
       } = parseNavigationParams(['signature', 'loginToken', 'address']);
 
       if (!address) {
+        setAccountProvider(emptyProvider);
+        dispatch(setWalletLogin(null));
         return clearNavigationHistory();
       }
 


### PR DESCRIPTION
- stop leaving app in an intermediary state if address is not found from wallet login