### PR TITLE
Fix npm version displayed in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A library that holds the core functional logic of a dapp on the MultiversX blockchain
 
-[![NPM](https://img.shields.io/npm/v/dapp-core.svg)](https://www.npmjs.com/package/@multiversx/sdk-dapp) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![NPM](https://img.shields.io/npm/v/@multiversx/sdk-dapp.svg)](https://www.npmjs.com/package/@multiversx/sdk-dapp) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 See [Dapp template](https://dapp-template.multiversx.com/) for live demo or checkout usage in the [Github repo](https://github.com/multiversx/mx-template-dapp)
 


### PR DESCRIPTION
Still shows version pre-rebranding

Before:
![Screenshot 2023-02-25 at 4 29 39 PM](https://user-images.githubusercontent.com/39144548/221365463-837981eb-eac9-417b-a996-45a8f303d23a.png)

After:
![Screenshot 2023-02-25 at 4 30 33 PM](https://user-images.githubusercontent.com/39144548/221365495-44c3db90-b6bc-4977-8df9-ece000f9b9f9.png)
