### PR TITLE
[+] NativeAuth origin and ScamPhishing auth message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Changed `host` and `hostname` to `origin` in `decodeNativeAuthToken` and `getNativeAuthConfig` return types. Added `authorizationInfo` prop in `ScamPhishinAlert` component](https://github.com/multiversx/mx-sdk-dapp/pull/673)
 
 ## [[v2.9.4](https://github.com/multiversx/mx-sdk-dapp/pull/673)] - 2023-02-26
 - [Fix message listening for Android](https://github.com/multiversx/mx-sdk-dapp/pull/672)

--- a/src/UI/ScamPhishingAlert/ScamPhishingAlert.tsx
+++ b/src/UI/ScamPhishingAlert/ScamPhishingAlert.tsx
@@ -5,32 +5,66 @@ import classNames from 'classnames';
 
 import styles from './scamPhishingStyles.scss';
 
+interface AuthorizationInfo {
+  url: string;
+  duration: string;
+}
+
 export interface ScamPhishingAlertPropsType {
   url: string;
   className?: string;
   icon?: ReactNode;
+  authorizationInfo?: AuthorizationInfo;
 }
 
 export const ScamPhishingAlert = (props: ScamPhishingAlertPropsType) => {
-  const { className, url, icon } = props;
+  const { className, url, icon, authorizationInfo } = props;
   const sanitizedUrl = url.replace('https://', '').replace(/\/$/, '');
+  const sanitizedAuthUrl = authorizationInfo?.url
+    ? authorizationInfo.url.replace('https://', '').replace(/\/$/, '')
+    : '';
 
   return (
-    <p className={classNames(styles.scamPhishingAlert, className)}>
-      {icon || (
-        <FontAwesomeIcon
-          className={styles.scamPhishingAlertIcon}
-          icon={faLock}
-        />
-      )}
+    <>
+      <p className={classNames(styles.scamPhishingAlert, className)}>
+        {icon || (
+          <FontAwesomeIcon
+            className={styles.scamPhishingAlertIcon}
+            icon={faLock}
+          />
+        )}
 
-      <span className={styles.scamPhishingAlertText}>
-        <span>Scam/Phishing verification:</span>{' '}
-        <span className={styles.scamPhishingAlertPrefix}>
-          <strong>https://</strong>
-          {sanitizedUrl}
+        <span className={styles.scamPhishingAlertText}>
+          <span>Scam/Phishing verification:</span>{' '}
+          <span className={styles.scamPhishingAlertPrefix}>
+            <strong>https://</strong>
+            {sanitizedUrl}
+          </span>
         </span>
-      </span>
-    </p>
+      </p>
+      {authorizationInfo?.url && (
+        <p
+          className={classNames(
+            styles.scamPhishingAlert,
+            'mt-2 column',
+            className
+          )}
+        >
+          <span className={styles.scamPhishingAlertText}>
+            <span>Please confirm that you are indeed connecting to</span>
+            <span className={styles.scamPhishingAlertPrefix}>
+              <strong>https://</strong>
+              {sanitizedAuthUrl} for{' '}
+              <strong>{authorizationInfo.duration}</strong> and that you trust
+              this site.
+            </span>
+          </span>
+          <span className={styles.scamPhishingAlertText}>
+            You might be sharing sensitive data.
+          </span>
+          <a href='https://multiversx.com/faq'>Learn more</a>
+        </p>
+      )}
+    </>
   );
 };

--- a/src/services/nativeAuth/helpers/decodeNativeAuthToken.tsx
+++ b/src/services/nativeAuth/helpers/decodeNativeAuthToken.tsx
@@ -13,15 +13,15 @@ export const decodeNativeAuthToken = (accessToken?: string) => {
     const [address, body, signature] = accessToken.split('.');
     const parsedAddress = decodeBase64(address);
     const parsedBody = decodeBase64(body);
-    const [host, blockHash, ttl, extraInfo] = parsedBody.split('.');
+    const [origin, blockHash, ttl, extraInfo] = parsedBody.split('.');
     const parsedExtraInfo = JSON.parse(decodeBase64(extraInfo));
-    const parsedHost = decodeBase64(host);
+    const parsedOrigin = decodeBase64(origin);
 
     const result = {
       ttl: Number(ttl),
       address: parsedAddress,
       extraInfo: parsedExtraInfo,
-      host: parsedHost,
+      origin: parsedOrigin,
       signature,
       blockHash,
       body: parsedBody

--- a/src/services/nativeAuth/helpers/tests/decodeNativeAuthToken.test.ts
+++ b/src/services/nativeAuth/helpers/tests/decodeNativeAuthToken.test.ts
@@ -14,7 +14,7 @@ describe('decodeNativeAuthToken tests', () => {
       extraInfo: {
         timestamp: 1669730934
       },
-      host: 'localhost',
+      origin: 'localhost',
       signature:
         '31c394d9b8532a412a707e22dbba20e87f3c9029df02b6b8d28857736059134419cf2ceb5340e83cab882d991771f629b2d4baca3d6f55a1ee31278a312f4707',
       ttl: 86400

--- a/src/services/nativeAuth/methods/getNativeAuthConfig.ts
+++ b/src/services/nativeAuth/methods/getNativeAuthConfig.ts
@@ -1,7 +1,7 @@
 import { NativeAuthConfigType } from 'types';
 
 const defaultNativeAuthConfig = {
-  hostname: typeof window !== 'undefined' ? window?.location?.hostname : '',
+  origin: typeof window !== 'undefined' ? window?.location?.hostname : '',
   apiAddress: 'https://api.multiversx.com',
   expirySeconds: 60 * 60 * 24, // one day
   tokenExpirationToastWarningSeconds: 5 * 60 // five minutes
@@ -13,7 +13,7 @@ export const getNativeAuthConfig = (config?: NativeAuthConfigType | true) => {
   }
 
   const nativeAuthConfig = {
-    hostname: config?.hostname ?? defaultNativeAuthConfig.hostname,
+    origin: config?.origin ?? defaultNativeAuthConfig.origin,
     blockHashShard: config?.blockHashShard ?? null,
     expirySeconds:
       config?.expirySeconds ?? defaultNativeAuthConfig.expirySeconds,

--- a/src/services/nativeAuth/nativeAuth.ts
+++ b/src/services/nativeAuth/nativeAuth.ts
@@ -7,14 +7,14 @@ import {
 import { getNativeAuthConfig, getToken, getTokenExpiration } from './methods';
 
 export const nativeAuth = (config?: NativeAuthConfigType) => {
-  const { hostname, apiAddress, expirySeconds, blockHashShard } =
+  const { origin, apiAddress, expirySeconds, blockHashShard } =
     getNativeAuthConfig(config) as NativeAuthConfigType;
 
   const initialize = async (
     extraInfo: any = {},
     latestBlockInfo?: LatestBlockHashType
   ): Promise<string> => {
-    if (!apiAddress || !hostname) {
+    if (!apiAddress || !origin) {
       return '';
     }
 
@@ -24,7 +24,7 @@ export const nativeAuth = (config?: NativeAuthConfigType) => {
     const encodedExtraInfo = encodeValue(
       JSON.stringify({ ...extraInfo, ...(timestamp ? { timestamp } : {}) })
     );
-    const host = encodeValue(hostname);
+    const host = encodeValue(origin);
 
     return `${host}.${hash}.${expirySeconds}.${encodedExtraInfo}`;
   };

--- a/src/services/nativeAuth/tests/nativeAuth.test.ts
+++ b/src/services/nativeAuth/tests/nativeAuth.test.ts
@@ -6,7 +6,7 @@ describe('Native Auth', () => {
   let mock: MockAdapter;
   const ADDRESS =
     'erd13rrn3fwjds8r5260n6q3pd2qa6wqkudrhczh26d957c0edyzermshds0k8';
-  const HOST = 'multiversx.com';
+  const ORIGIN = 'multiversx.com';
   const SIGNATURE =
     '4b445f287663b868e269aa0532c9fd73acb37cfd45f46e33995777e68e5ecc15d97318d9af09c4102f9b40ecf347a75e2d2e81acbcc3c72ae32fcf659c2acd0e';
   const BLOCK_HASH =
@@ -33,7 +33,7 @@ describe('Native Auth', () => {
   describe('Client', () => {
     it('Latest block should return signable token', async () => {
       const client = nativeAuth({
-        hostname: HOST,
+        origin: ORIGIN,
         apiAddress: 'https://api.multiversx.com'
       });
 
@@ -52,7 +52,7 @@ describe('Native Auth', () => {
         .useFakeTimers()
         .setSystemTime(new Date().setSeconds(new Date().getSeconds() + 60));
       const client = nativeAuth({
-        hostname: HOST,
+        origin: ORIGIN,
         apiAddress: 'https://api.multiversx.com'
       });
 
@@ -61,7 +61,7 @@ describe('Native Auth', () => {
 
     it('Generate Access token', () => {
       const client = nativeAuth({
-        hostname: HOST,
+        origin: ORIGIN,
         apiAddress: 'https://api.multiversx.com'
       });
 

--- a/src/types/login.types.ts
+++ b/src/types/login.types.ts
@@ -23,7 +23,7 @@ export type OnLoginRedirectType = (
 ) => void;
 
 export interface NativeAuthConfigType {
-  hostname?: string;
+  origin?: string;
   apiAddress?: string;
   expirySeconds?: number;
   blockHashShard?: number;


### PR DESCRIPTION
Changed `host` and `hostname` to `origin` in `decodeNativeAuthToken` and `getNativeAuthConfig` return types. Added `authorizationInfo` prop in `ScamPhishinAlert` component