### PR TITLE
[+] Updated `decodeLoginToken` to call `decodeNativeAuthToken` when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Updated `decodeLoginToken` to call `decodeNativeAuthToken` when necessary](https://github.com/multiversx/mx-sdk-dapp/pull/742)]
 
 ## [[v2.12.0]](https://github.com/multiversx/mx-sdk-dapp/pull/737)] - 2023-04-25
 - [Added `dappConfig` slice to control setting `webViewLogin`](https://github.com/multiversx/mx-sdk-dapp/pull/731)]

--- a/src/services/nativeAuth/helpers/decodeLoginToken.ts
+++ b/src/services/nativeAuth/helpers/decodeLoginToken.ts
@@ -1,5 +1,6 @@
 import isString from 'lodash/isString';
 import { decodeBase64 } from 'utils/decoders/base64Utils';
+import { decodeNativeAuthToken } from './decodeNativeAuthToken';
 
 export interface DecodedLoginTokenType {
   blockHash: string;
@@ -17,11 +18,11 @@ export const decodeLoginToken = (
 
   const parts = loginToken.split('.');
 
-  if (parts.length !== 4) {
-    console.error(
-      'Invalid loginToken. You may be trying to decode a nativeAuthToken. Try using decodeNativeAuthToken method instead'
-    );
+  if (parts.length === 3) {
+    return decodeNativeAuthToken(loginToken);
+  }
 
+  if (parts.length !== 4) {
     return null;
   }
 


### PR DESCRIPTION
### Issue
There is a confusion of when `decodeLoginToken` and `decodeNativeAuthToken` should be called and some users may accidentally call the wrong function

### Reproduce
Call `decodeLoginToken` with a nativeAuthToken and an error will be thrown

### Root cause
Within the `decodeLoginToken` there is no check if the token is a login or nativeAuth one. There is such check in `decodeNativeAuthToken` function however.

### Fix
Call `decodeNativeAuthToken` within `decodeLoginToken` if the token has 3 parts
```
  if (parts.length === 3) {
    return decodeNativeAuthToken(loginToken);
  }
```
and call `decodeLoginToken` within `decodeNativeAuthToken` if the token has 4 parts

```
if (parts.length === 4) {
    const parsedInitToken = decodeLoginToken(accessToken);

    if (!parsedInitToken) {
      return null;
    }

    const { ttl, extraInfo, origin, blockHash } = parsedInitToken;

    return {
      ttl,
      extraInfo,
      origin,
      blockHash,
      address: '',
      body: accessToken,
      signature: ''
    };
  }
```

Return `null` whenever the token is invalid or falsy