### PR TITLE
Fix setting webview provider

### DIFF
--- a/src/wrappers/DappProvider/DappProvider.tsx
+++ b/src/wrappers/DappProvider/DappProvider.tsx
@@ -41,8 +41,7 @@ export const DappProvider = ({
 
   if (externalProvider != null) {
     setExternalProvider(externalProvider);
-  }
-  if (dappConfig?.shouldUseWebViewProvider) {
+  } else if (dappConfig?.shouldUseWebViewProvider) {
     setExternalProvider(webviewProvider);
   }
 


### PR DESCRIPTION
`WebviewProvider` was overrinding external provider
**Solution**: only set it if `shouldUseWebViewProvider` is `true` and no external provider is present