### PR TITLE
2fa hook ledger hashSign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Added `hashSign` option to ledger guarded transactions`](https://github.com/multiversx/mx-sdk-dapp/pull/747)]
 ## [[v2.12.2]](https://github.com/multiversx/mx-sdk-dapp/pull/748)] - 2023-04-28
 - [Extend `GuardianScreenType` with `address`](https://github.com/multiversx/mx-sdk-dapp/pull/747)]
 - [Fixed transaction data parsing in `newTransaction` method](https://github.com/multiversx/mx-sdk-dapp/pull/744)]

--- a/src/hooks/transactions/helpers/checkNeedsGuardianSigning.ts
+++ b/src/hooks/transactions/helpers/checkNeedsGuardianSigning.ts
@@ -1,0 +1,64 @@
+import { Transaction } from '@multiversx/sdk-core';
+import { getEnvironmentForChainId } from 'apiCalls/configuration';
+import {
+  WALLET_SIGN_SESSION,
+  fallbackNetworkConfigurations
+} from 'constants/index';
+
+import { newWalletProvider } from 'providers/utils';
+import { builtCallbackUrl } from 'utils/transactions/builtCallbackUrl';
+import { getAreAllTransactionsSignedByGuardian } from './getAreAllTransactionsSignedByGuardian';
+
+interface SendTransactionsToGuardianType {
+  transactions: Transaction[];
+  hasGuardianScreen?: boolean;
+  isGuarded?: boolean;
+  callbackRoute?: string;
+  sessionId?: string;
+  walletAddress?: string;
+}
+
+export const checkNeedsGuardianSigning = ({
+  transactions,
+  hasGuardianScreen,
+  callbackRoute,
+  sessionId,
+  walletAddress,
+  isGuarded
+}: SendTransactionsToGuardianType) => {
+  const allSignedByGuardian = getAreAllTransactionsSignedByGuardian({
+    isGuarded,
+    transactions
+  });
+
+  /**
+   * Redirect to wallet for signing if:
+   * - account is guarded &
+   * - 2FA will not be provided locally &
+   * - transactions were not signed by guardian
+   */
+  const sendTransactionsToGuardian = () => {
+    const chainId = transactions[0].getChainID().valueOf();
+    const environment = getEnvironmentForChainId(chainId);
+    const walletProviderAddress =
+      walletAddress ?? fallbackNetworkConfigurations[environment].walletAddress;
+    const walletProvider = newWalletProvider(walletProviderAddress);
+    const urlParams = { [WALLET_SIGN_SESSION]: String(sessionId) };
+    const callbackUrl = window?.location
+      ? `${window.location.origin}${callbackRoute}`
+      : `${callbackRoute}`;
+    const builtedCallbackUrl = builtCallbackUrl({ callbackUrl, urlParams });
+
+    walletProvider.guardTransactions(transactions, {
+      callbackUrl: encodeURIComponent(builtedCallbackUrl)
+    });
+  };
+
+  const needs2FaSigning =
+    isGuarded && !hasGuardianScreen && !allSignedByGuardian && sessionId;
+
+  return {
+    needs2FaSigning,
+    sendTransactionsToGuardian
+  };
+};

--- a/src/hooks/transactions/helpers/index.ts
+++ b/src/hooks/transactions/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './getShouldMoveTransactionsToSignedState';
 export * from './useSetTransactionNonces';
 export * from './getAreAllTransactionsSignedByGuardian';
+export * from './checkNeedsGuardianSigning';

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -1,17 +1,12 @@
 import { Transaction } from '@multiversx/sdk-core';
-import { getEnvironmentForChainId } from 'apiCalls/configuration';
 import { getScamAddressData } from 'apiCalls/getScamAddressData';
-import {
-  WALLET_SIGN_SESSION,
-  fallbackNetworkConfigurations
-} from 'constants/index';
+
 import { useGetAccountInfo } from 'hooks/account/useGetAccountInfo';
 import { useGetAccountProvider } from 'hooks/account/useGetAccountProvider';
 import { useSignMultipleTransactions } from 'hooks/transactions/useSignMultipleTransactions';
 
-import { newWalletProvider } from 'providers/utils';
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
-import { egldLabelSelector } from 'reduxStore/selectors';
+import { egldLabelSelector, networkSelector } from 'reduxStore/selectors';
 import {
   moveTransactionsToSignedState,
   setSignTransactionsError
@@ -25,9 +20,8 @@ import {
 } from 'types';
 import { getIsProviderEqualTo } from 'utils/account/getIsProviderEqualTo';
 import { safeRedirect } from 'utils/redirect';
-import { builtCallbackUrl } from 'utils/transactions/builtCallbackUrl';
 import { parseTransactionAfterSigning } from 'utils/transactions/parseTransactionAfterSigning';
-import { getAreAllTransactionsSignedByGuardian } from './helpers';
+import { checkNeedsGuardianSigning } from './helpers';
 import { getShouldMoveTransactionsToSignedState } from './helpers/getShouldMoveTransactionsToSignedState';
 import { useClearTransactionsToSignWithWarning } from './helpers/useClearTransactionsToSignWithWarning';
 import { useSignTransactionsCommonData } from './useSignTransactionsCommonData';
@@ -61,6 +55,7 @@ export function useSignTransactionsWithDevice(
   const { onCancel, verifyReceiverScam = true, hasGuardianScreen } = props;
   const { transactionsToSign, hasTransactions } =
     useSignTransactionsCommonData();
+  const network = useSelector(networkSelector);
 
   const egldLabel = useSelector(egldLabelSelector);
   const { account } = useGetAccountInfo();
@@ -100,32 +95,18 @@ export function useSignTransactionsWithDevice(
       return;
     }
 
-    const allSignedByGuardian = getAreAllTransactionsSignedByGuardian({
-      isGuarded,
-      transactions: newSignedTransactions
-    });
-
-    /**
-     * Redirect to wallet for signing if:
-     * - account is guarded &
-     * - 2FA will not be provided locally &
-     * - transactions were not signed by guardian
-     */
-    if (isGuarded && !hasGuardianScreen && !allSignedByGuardian) {
-      const chainId = newSignedTransactions[0].getChainID().valueOf();
-      const environment = getEnvironmentForChainId(chainId);
-      const walletAddress =
-        fallbackNetworkConfigurations[environment].walletAddress;
-      const walletProvider = newWalletProvider(walletAddress);
-      const urlParams = { [WALLET_SIGN_SESSION]: String(sessionId) };
-      const callbackUrl = window?.location
-        ? `${window.location.origin}${callbackRoute}`
-        : `${callbackRoute}`;
-      const builtedCallbackUrl = builtCallbackUrl({ callbackUrl, urlParams });
-
-      walletProvider.guardTransactions(newSignedTransactions, {
-        callbackUrl: encodeURIComponent(builtedCallbackUrl)
+    const { needs2FaSigning, sendTransactionsToGuardian } =
+      checkNeedsGuardianSigning({
+        transactions: newSignedTransactions,
+        sessionId,
+        callbackRoute,
+        hasGuardianScreen,
+        isGuarded,
+        walletAddress: network.walletAddress
       });
+
+    if (needs2FaSigning) {
+      return sendTransactionsToGuardian();
     }
 
     if (sessionId) {

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -59,7 +59,7 @@ export function useSignTransactionsWithDevice(
 
   const egldLabel = useSelector(egldLabelSelector);
   const { account } = useGetAccountInfo();
-  const { address, isGuarded } = account;
+  const { address, isGuarded, activeGuardianAddress } = account;
   const { provider } = useGetAccountProvider();
   const dispatch = useDispatch();
   const clearTransactionsToSignWithWarning =
@@ -142,10 +142,11 @@ export function useSignTransactionsWithDevice(
   const signMultipleTxReturnValues = useSignMultipleTransactions({
     address,
     egldLabel,
-    isGuarded,
+    activeGuardianAddress,
     transactionsToSign: hasTransactions ? transactions : [],
     onGetScamAddressData: verifyReceiverScam ? getScamAddressData : null,
     isLedger: getIsProviderEqualTo(LoginMethodsEnum.ledger),
+    hasGuardianScreen,
     onCancel: handleCancel,
     onSignTransaction: handleSignTransaction,
     onTransactionsSignError: handleTransactionSignError,


### PR DESCRIPTION
### Issue
- transaction data for ledger was not set correctly when signing with guardian

### Reproduce
Issue exists on version `2.12.2` of sdk-dapp.

### Root cause
- `hashSign` option was not being added to transactions
### Fix
- add `hashSign` to `useSignMultipleTransactions`
### Additional changes
- create `checkNeedsGuardianSigning` helper
### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
