### PR TITLE
[+] Added `ledgerSignature` to assets in `TokenType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Added `ledgerSignature` to assets in `TokenType`](https://github.com/multiversx/mx-sdk-dapp/pull/756)]
 - [Fixed checking of base64 encoding in transaction data field](https://github.com/multiversx/mx-sdk-dapp/pull/755)]
 ## [[v2.12.4]](https://github.com/multiversx/mx-sdk-dapp/pull/750)] - 2023-05-03
 - [Fixed setting `hasGuardianScreen` flag in `useSignTransactionsWithDevice`](https://github.com/multiversx/mx-sdk-dapp/pull/749)]

--- a/src/types/tokens.types.ts
+++ b/src/types/tokens.types.ts
@@ -52,6 +52,7 @@ export interface TokenType {
     social?: any;
     extraTokens?: string[];
     lockedAccounts?: { [key: string]: string };
+    ledgerSignature?: string;
   };
 }
 


### PR DESCRIPTION
### Issue/Feature
`ledgerSignature` is missing in `assets` field of `TokenType`

### Reproduce
Issue exists on version `2.12.4` of sdk-dapp.

### Root cause
`ledgerSignature` is missing in `assets` field of `TokenType`

### Fix
Add `ledgerSignature` in `assets` field of `TokenType`

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
