### PR TITLE
Extend calculate fee limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Extend calculateFeeLimit with isGuarded flag](https://github.com/multiversx/mx-sdk-dapp/pull/759)
 ## [[v2.12.6]](https://github.com/multiversx/mx-sdk-dapp/pull/758)] - 2023-05-05
 - [Increment extension provider version](https://github.com/multiversx/mx-sdk-dapp/pull/758)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Extend calculateFeeLimit with isGuarded flag](https://github.com/multiversx/mx-sdk-dapp/pull/759)
+- [Extend `calculateFeeLimit` with isGuarded flag](https://github.com/multiversx/mx-sdk-dapp/pull/759)
 ## [[v2.12.6]](https://github.com/multiversx/mx-sdk-dapp/pull/758)] - 2023-05-05
 - [Increment extension provider version](https://github.com/multiversx/mx-sdk-dapp/pull/758)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Extend `calculateFeeLimit` with isGuarded flag](https://github.com/multiversx/mx-sdk-dapp/pull/759)
+- [Extend `calculateFeeLimit` with isGuarded flag](https://github.com/multiversx/mx-sdk-dapp/pull/760)
 ## [[v2.12.6]](https://github.com/multiversx/mx-sdk-dapp/pull/758)] - 2023-05-05
 - [Increment extension provider version](https://github.com/multiversx/mx-sdk-dapp/pull/758)
 

--- a/src/utils/operations/calculateFeeLimit.ts
+++ b/src/utils/operations/calculateFeeLimit.ts
@@ -27,9 +27,7 @@ export interface CalculateFeeLimitType {
 }
 const placeholderData = {
   from: 'erd12dnfhej64s6c56ka369gkyj3hwv5ms0y5rxgsk2k7hkd2vuk7rvqxkalsa',
-  to: 'erd12dnfhej64s6c56ka369gkyj3hwv5ms0y5rxgsk2k7hkd2vuk7rvqxkalsa',
-  guardianSignature:
-    '22946258b3307f477003cfbe228d49a1c4dc1f139235fff1aedad65bc4051a11dd79be7979030284440611f25ed483fccaee0f18b03a513f48de91cdfacd000e'
+  to: 'erd12dnfhej64s6c56ka369gkyj3hwv5ms0y5rxgsk2k7hkd2vuk7rvqxkalsa'
 };
 
 export function calculateFeeLimit({

--- a/src/utils/operations/tests/calculateFeeLimit.test.tsx
+++ b/src/utils/operations/tests/calculateFeeLimit.test.tsx
@@ -25,17 +25,4 @@ describe('calculateFeeLimit tests', () => {
     });
     expect(feeLimit).toBe('210990000000000');
   });
-  it('computes correct fee for guarded account', () => {
-    const feeLimit = calculateFeeLimit({
-      gasLimit: '11100000',
-      gasPrice: '1000000000',
-      data: 'bid@0d59@43525a502d333663366162@25',
-      gasPerDataByte: '1500',
-      defaultGasPrice: '1000000000',
-      gasPriceModifier: '0.01',
-      chainId: 'T',
-      isGuarded: true
-    });
-    expect(feeLimit).toBe('211490000000000');
-  });
 });

--- a/src/utils/operations/tests/calculateFeeLimit.test.tsx
+++ b/src/utils/operations/tests/calculateFeeLimit.test.tsx
@@ -25,4 +25,17 @@ describe('calculateFeeLimit tests', () => {
     });
     expect(feeLimit).toBe('210990000000000');
   });
+  it('computes correct fee for guarded account', () => {
+    const feeLimit = calculateFeeLimit({
+      gasLimit: '11100000',
+      gasPrice: '1000000000',
+      data: 'bid@0d59@43525a502d333663366162@25',
+      gasPerDataByte: '1500',
+      defaultGasPrice: '1000000000',
+      gasPriceModifier: '0.01',
+      chainId: 'T',
+      isGuarded: true
+    });
+    expect(feeLimit).toBe('211490000000000');
+  });
 });


### PR DESCRIPTION
### Feature
- allow calculateFeeLimit to show correct fee for guarded transactions
### Reproduce
Issue exists on version `2.12.6` of sdk-dapp.

### Root cause
- estimated fee was the same for all transactions
### Fix
- add integration of `isGuarded` flag to `calculateFeeLimit` helper
### Additional changes
- replace TokenPayment with TokenTransfer
### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
