### PR TITLE
Skip guardian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Allow skip guradian for change guardian transaction](https://github.com/multiversx/mx-sdk-dapp/pull/761)
 ## [[v2.12.6]](https://github.com/multiversx/mx-sdk-dapp/pull/758)] - 2023-05-05
 - [Increment extension provider version](https://github.com/multiversx/mx-sdk-dapp/pull/758)
 

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -173,7 +173,7 @@ export const useSignTransactions = () => {
     try {
       isSigningRef.current = true;
       const signedTransactions: Transaction[] = await provider.signTransactions(
-        isGuarded
+        isGuarded && !customTransactionInformation.skipGuardian
           ? transactions.map((transaction) => {
               transaction.setVersion(TransactionVersion.withTxOptions());
               transaction.setOptions(

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -142,7 +142,10 @@ export function useSignTransactionsWithDevice(
   const signMultipleTxReturnValues = useSignMultipleTransactions({
     address,
     egldLabel,
-    activeGuardianAddress,
+    activeGuardianAddress:
+      isGuarded && customTransactionInformation?.skipGuardian
+        ? activeGuardianAddress
+        : undefined,
     transactionsToSign: hasTransactions ? transactions : [],
     onGetScamAddressData: verifyReceiverScam ? getScamAddressData : null,
     isLedger: getIsProviderEqualTo(LoginMethodsEnum.ledger),

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -204,6 +204,10 @@ export interface CustomTransactionInformation {
   sessionInformation: any;
   completedTransactionsDelay?: number;
   signWithoutSending: boolean;
+  /**
+   * If true, the change guardian action will not trigger transaction version update
+   */
+  skipGuardian?: boolean;
 }
 
 export interface SendTransactionReturnType {


### PR DESCRIPTION
### Issue
- cannot perform change guardian address without access to guardian app
### Reproduce
Issue exists on version `2.12.6` of sdk-dapp.

### Root cause

### Fix
- allow setting customTransactionInformation skipGuardian
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
