### PR TITLE
Fix skip guardian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed setting `skipGuardian` condtion](https://github.com/multiversx/mx-sdk-dapp/pull/761)
 ## [[v2.12.7]](https://github.com/multiversx/mx-sdk-dapp/pull/762)] - 2023-05-05
 - [Allow skip guradian for change guardian transaction](https://github.com/multiversx/mx-sdk-dapp/pull/761)
 ## [[v2.12.6]](https://github.com/multiversx/mx-sdk-dapp/pull/758)] - 2023-05-05

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -170,10 +170,12 @@ export const useSignTransactions = () => {
       return;
     }
 
+    const allowGuardian = !customTransactionInformation.skipGuardian;
+
     try {
       isSigningRef.current = true;
       const signedTransactions: Transaction[] = await provider.signTransactions(
-        isGuarded && !customTransactionInformation.skipGuardian
+        isGuarded && allowGuardian
           ? transactions.map((transaction) => {
               transaction.setVersion(TransactionVersion.withTxOptions());
               transaction.setOptions(

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -139,13 +139,13 @@ export function useSignTransactionsWithDevice(
     return await provider.signTransaction(transaction);
   }
 
+  const allowGuardian = !customTransactionInformation?.skipGuardian;
+
   const signMultipleTxReturnValues = useSignMultipleTransactions({
     address,
     egldLabel,
     activeGuardianAddress:
-      isGuarded && customTransactionInformation?.skipGuardian
-        ? activeGuardianAddress
-        : undefined,
+      isGuarded && allowGuardian ? activeGuardianAddress : undefined,
     transactionsToSign: hasTransactions ? transactions : [],
     onGetScamAddressData: verifyReceiverScam ? getScamAddressData : null,
     isLedger: getIsProviderEqualTo(LoginMethodsEnum.ledger),

--- a/src/services/transactions/sendTransactions.ts
+++ b/src/services/transactions/sendTransactions.ts
@@ -15,6 +15,7 @@ export async function sendTransactions({
   signWithoutSending,
   completedTransactionsDelay,
   sessionInformation,
+  skipGuardian,
   minGasLimit
 }: SendTransactionsPropsType): Promise<SendTransactionReturnType> {
   try {
@@ -42,6 +43,7 @@ export async function sendTransactions({
         redirectAfterSign,
         completedTransactionsDelay,
         sessionInformation,
+        skipGuardian,
         signWithoutSending
       }
     });

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -132,6 +132,7 @@ export interface SendTransactionsPropsType {
     | (Transaction | SimpleTransactionType)[];
   redirectAfterSign?: boolean;
   signWithoutSending: boolean;
+  skipGuardian?: boolean;
   completedTransactionsDelay?: number;
   callbackRoute?: string;
   transactionsDisplayInfo: TransactionsDisplayInfoType;


### PR DESCRIPTION
### Issue
- skipGuardian flag was not being passed from sendTransactions
### Reproduce
Issue exists on version `2.12.7` of sdk-dapp.

### Root cause

### Fix
- added skipGuardian flag to sendTransactions
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
