### PR TITLE
Fix guardian redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed redirect to 2FA hook when `skipGuardian` is set](https://github.com/multiversx/mx-sdk-dapp/pull/763)
 ## [[v2.12.8]](https://github.com/multiversx/mx-sdk-dapp/pull/762)] - 2023-05-08
 - [Fixed setting `skipGuardian` condtion](https://github.com/multiversx/mx-sdk-dapp/pull/761)
 ## [[v2.12.7]](https://github.com/multiversx/mx-sdk-dapp/pull/762)] - 2023-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Fixed redirect to 2FA hook when `skipGuardian` is set](https://github.com/multiversx/mx-sdk-dapp/pull/764)
-- [Fixed incorrect returns of `signMessage`](https://github.com/multiversx/mx-sdk-dapp/pull/763)
+- [Fixed redirect to 2FA hook when `skipGuardian` is set](https://github.com/multiversx/mx-sdk-dapp/pull/766)
+- [Fixed incorrect returns of `signMessage`](https://github.com/multiversx/mx-sdk-dapp/pull/765)
 
 ## [[v2.12.8]](https://github.com/multiversx/mx-sdk-dapp/pull/762)] - 2023-05-08
 - [Fixed setting `skipGuardian` condtion](https://github.com/multiversx/mx-sdk-dapp/pull/761)

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -203,7 +203,7 @@ export const useSignTransactions = () => {
           transactions: signedTransactions,
           sessionId,
           callbackRoute,
-          isGuarded,
+          isGuarded: isGuarded && allowGuardian,
           walletAddress: network.walletAddress
         });
 

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -87,6 +87,8 @@ export function useSignTransactionsWithDevice(
   const locationIncludesCallbackRoute =
     callbackRoute != null && window?.location.pathname.includes(callbackRoute);
 
+  const allowGuardian = !customTransactionInformation?.skipGuardian;
+
   function handleTransactionsSignSuccess(newSignedTransactions: Transaction[]) {
     const shouldMoveTransactionsToSignedState =
       getShouldMoveTransactionsToSignedState(newSignedTransactions);
@@ -101,7 +103,7 @@ export function useSignTransactionsWithDevice(
         sessionId,
         callbackRoute,
         hasGuardianScreen,
-        isGuarded,
+        isGuarded: isGuarded && allowGuardian,
         walletAddress: network.walletAddress
       });
 
@@ -138,8 +140,6 @@ export function useSignTransactionsWithDevice(
   async function handleSignTransaction(transaction: Transaction) {
     return await provider.signTransaction(transaction);
   }
-
-  const allowGuardian = !customTransactionInformation?.skipGuardian;
 
   const signMultipleTxReturnValues = useSignMultipleTransactions({
     address,


### PR DESCRIPTION
### Issue
- when skipGuardian was set, user was still being redirected to 2FA hook in wallet

### Reproduce
Issue exists on version `2.12.8` of sdk-dapp.

### Root cause

### Fix
- add condition for skipGuardian when checking if needs2FaSigning
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User tesing
[] Unit tests
