### PR TITLE
Fix handle unsent batch transactions

### DIFF
--- a/src/components/BatchTransactionsSender/BatchTransactionsSender.ts
+++ b/src/components/BatchTransactionsSender/BatchTransactionsSender.ts
@@ -41,6 +41,7 @@ export const BatchTransactionsSender = () => {
   const signedTransactions = useSelector(signedTransactionsSelector);
 
   const sendingRef = useRef(false);
+  const sentSessionIds = useRef<string[]>([]);
 
   const clearSignInfo = () => {
     dispatch(clearAllTransactionsToSign());
@@ -82,6 +83,10 @@ export const BatchTransactionsSender = () => {
         continue;
       }
 
+      if (sentSessionIds.current.includes(sessionId)) {
+        continue;
+      }
+
       const { transactions } = session;
       if (!transactions) {
         continue;
@@ -114,6 +119,7 @@ export const BatchTransactionsSender = () => {
           continue;
         }
 
+        sentSessionIds.current.push(sessionId);
         const response = await sendBatchTransactions({
           transactions: groupedTransactions,
           sessionId,

--- a/src/hooks/transactions/batch/tracker/useUpdateBatch.ts
+++ b/src/hooks/transactions/batch/tracker/useUpdateBatch.ts
@@ -1,14 +1,17 @@
-import { refreshAccount } from 'utils/account/refreshAccount';
-import { useGetBatches } from '../useGetBatches';
-import { sequentialToFlatArray } from 'utils/transactions/batch/sequentialToFlatArray';
-import { store } from 'reduxStore/store';
-import { updateSignedTransactionStatus } from 'reduxStore/slices';
-import { TransactionServerStatusesEnum } from 'types';
-import { getTransactionsDetails } from 'services/transactions/getTransactionsDetails';
 import { useCallback } from 'react';
+import { useSelector } from 'reduxStore/DappProviderContext';
+import { signedTransactionsSelector } from 'reduxStore/selectors';
+import { updateSignedTransactionStatus } from 'reduxStore/slices';
+import { store } from 'reduxStore/store';
+import { getTransactionsDetails } from 'services/transactions/getTransactionsDetails';
+import { TransactionServerStatusesEnum } from 'types';
+import { refreshAccount } from 'utils/account/refreshAccount';
+import { sequentialToFlatArray } from 'utils/transactions/batch/sequentialToFlatArray';
+import { useGetBatches } from '../useGetBatches';
 
 export function useUpdateBatch() {
   const { batchTransactionsArray } = useGetBatches();
+  const signedTransactions = useSelector(signedTransactionsSelector);
 
   return useCallback(
     async (props?: {
@@ -17,7 +20,7 @@ export function useUpdateBatch() {
       dropUnprocessedTransactions?: boolean;
       shouldRefreshBalance?: boolean;
     }) => {
-      if(!props) {
+      if (!props) {
         return;
       }
 
@@ -53,7 +56,9 @@ export function useUpdateBatch() {
       }
 
       const { data, success } = await getTransactionsDetails(
-        transactionsFlatArray.map(({ hash }) => hash)
+        transactionsFlatArray
+          .map(({ hash }) => hash)
+          .filter((hash) => Boolean(hash))
       );
 
       if (success && data) {
@@ -78,6 +83,28 @@ export function useUpdateBatch() {
               sessionId,
               status: apiTx.status as TransactionServerStatusesEnum,
               transactionHash: transaction.hash
+            })
+          );
+        }
+      } else {
+        for (const transaction of transactionsFlatArray) {
+          if (!signedTransactions) {
+            continue;
+          }
+
+          const signedTransaction = signedTransactions[
+            sessionId
+          ]?.transactions?.find((tx) => tx.signature === transaction.signature);
+
+          if (!signedTransaction) {
+            continue;
+          }
+
+          store.dispatch(
+            updateSignedTransactionStatus({
+              sessionId,
+              status: TransactionServerStatusesEnum.notExecuted,
+              transactionHash: signedTransaction.hash
             })
           );
         }

--- a/src/services/transactions/getTransactionsDetails.ts
+++ b/src/services/transactions/getTransactionsDetails.ts
@@ -8,6 +8,10 @@ export const getTransactionsDetails = async (txHashes: string[]) => {
   let retries = 4;
   let transactions: ServerTransactionType[] | undefined;
 
+  if (txHashes.length === 0) {
+    return { data: transactions, success: false };
+  }
+
   while (transactions === undefined && retries > 0) {
     try {
       await delayWithPromise(delayMs);


### PR DESCRIPTION
### Issue/Feature
Some batches are not processed by the service and have missing transaction hashes
Duplicate batch transactions send
### Reproduce
Issue exists on version `2.13` of sdk-dapp.

### Root cause
Batch transactions service
Error in the batch transactions send flow (duplicate send)
### Fix
Handle this case in order to resolve the toast with the correct status (notExecuted)
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
