### PR TITLE
[FIX] Fix `dappConfig` not saved in redux store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- [Fix `dappConfig` not saved in redux store](https://github.com/multiversx/mx-sdk-dapp/pull/776)
 - [Fix cancel transactions flow with web wallet provider](https://github.com/multiversx/mx-sdk-dapp/pull/774)
 
 ## [[v2.13.2]](https://github.com/multiversx/mx-sdk-dapp/pull/773)] - 2023-05-09

--- a/src/reduxStore/selectors/index.ts
+++ b/src/reduxStore/selectors/index.ts
@@ -1,4 +1,5 @@
 export * from './accountInfoSelectors';
+export * from './dappConfigSelector';
 export * from './loginInfoSelectors';
 export * from './modalsSelectors';
 export * from './networkConfigSelectors';
@@ -6,4 +7,3 @@ export * from './signedMessageInfoSelectors';
 export * from './toastsSelectors';
 export * from './transactionsInfoSelectors';
 export * from './transactionsSelectors';
-export * from './dappConfigSelector';

--- a/src/reduxStore/slices/dappConfigSlice.ts
+++ b/src/reduxStore/slices/dappConfigSlice.ts
@@ -14,7 +14,13 @@ export const dappConfigSlice = createSlice({
       state: DappConfigSliceStateType,
       action: PayloadAction<DappConfigSliceStateType>
     ) => {
-      state = { ...state, ...action.payload };
+      if (state && action.payload) {
+        const { logoutRoute, shouldUseWebViewProvider } = action.payload;
+        state.logoutRoute = logoutRoute;
+        state.shouldUseWebViewProvider = shouldUseWebViewProvider;
+      } else {
+        state = action.payload;
+      }
     }
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
### Issue
`shouldUseWebViewProvider` is `undefined` when selecting it from redux store via `shouldUseWebViewProviderSelector`

### Reproduce
Issue exists on version `2.13.2` of sdk-dapp.

### Root cause
`dappConfig` is not updated when using `dispatch(setDappConfig(dappConfig))`. It is always an empty object, because the `setDappConfig` action is not handled correctly in the reducer.

### Fix
Instead of creating a new state at `setDappConfig`, update the same state's properties one by one. Before the state object was reassigned with a new object. This doesn't work because the state parameter is not a variable but a reference to the current state. When you reassign state, you're not changing the original state object that Redux holds, but only the local reference inside your reducer function. This is why Redux state does not get updated.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
