### PR TITLE
Tm fix ledger double sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Stop ledger double signing before leaving sign screen to 2FA hook](https://github.com/multiversx/mx-sdk-dapp/pull/777)
 - [Fix `dappConfig` not saved in redux store](https://github.com/multiversx/mx-sdk-dapp/pull/776)
 - [Fix cancel transactions flow with web wallet provider](https://github.com/multiversx/mx-sdk-dapp/pull/774)
 

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Transaction } from '@multiversx/sdk-core';
 import { getScamAddressData } from 'apiCalls/getScamAddressData';
 
@@ -64,6 +65,7 @@ export function useSignTransactionsWithDevice(
   const dispatch = useDispatch();
   const clearTransactionsToSignWithWarning =
     useClearTransactionsToSignWithWarning();
+  const [isSignDisabled, setIsSignDisabled] = useState<boolean>();
 
   const {
     transactions,
@@ -108,6 +110,7 @@ export function useSignTransactionsWithDevice(
       });
 
     if (needs2FaSigning) {
+      setIsSignDisabled(true); // prevent user from pressing sign button again while page is redirecting
       return sendTransactionsToGuardian();
     }
 
@@ -155,5 +158,11 @@ export function useSignTransactionsWithDevice(
     onTransactionsSignError: handleTransactionSignError,
     onTransactionsSignSuccess: handleTransactionsSignSuccess
   });
-  return { ...signMultipleTxReturnValues, callbackRoute };
+
+  return {
+    ...signMultipleTxReturnValues,
+    callbackRoute,
+    waitingForDevice:
+      isSignDisabled ?? signMultipleTxReturnValues.waitingForDevice
+  };
 }


### PR DESCRIPTION
### Issue
- prevent ledger Sign screen button being active before redirecting to 2FA hook
### Reproduce
Issue exists on version `2.13` of sdk-dapp.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
