### PR TITLE
[FIX] Added flag to prevent updating nonce when signing transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Added flag to prevent updating nonce when signing transactions](https://github.com/multiversx/mx-sdk-dapp/pull/778)
+
 ## [[v2.13.3]](https://github.com/multiversx/mx-sdk-dapp/pull/773)] - 2023-05-10
 - [Stop ledger double signing before leaving sign screen to 2FA hook](https://github.com/multiversx/mx-sdk-dapp/pull/777)
 - [Fix `dappConfig` not saved in redux store](https://github.com/multiversx/mx-sdk-dapp/pull/776)

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -68,6 +68,7 @@ export const useSignTransactions = () => {
     error,
     setError,
     hasTransactions,
+    preventNonceUpdate,
     onAbort,
     clearTransactionStatusMessage
   } = useSignTransactionsCommonData();
@@ -267,9 +268,9 @@ export const useSignTransactions = () => {
     try {
       const isSigningWithWebWallet = providerType === LoginMethodsEnum.wallet;
 
-      const transactionsWithIncrementalNonces = await setTransactionNonces(
-        transactions
-      );
+      const transactionsWithIncrementalNonces = preventNonceUpdate
+        ? transactions
+        : await setTransactionNonces(transactions);
 
       if (isSigningWithWebWallet) {
         return signWithWallet(

--- a/src/hooks/transactions/useSignTransactionsCommonData.tsx
+++ b/src/hooks/transactions/useSignTransactionsCommonData.tsx
@@ -27,6 +27,7 @@ export const useSignTransactionsCommonData = () => {
   const [error, setError] = useState<string | null>(null);
   const [hasTransactions, setHasTransactions] = useState<boolean>();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [preventNonceUpdate, setPreventNonceUpdate] = useState<boolean>(false);
 
   const setTransactionNonces = useSetTransactionNonces();
   const transactionsToSign = useSelector(transactionsToSignSelector);
@@ -39,9 +40,18 @@ export const useSignTransactionsCommonData = () => {
     const transactionsWithFixedNonce = transactionsToSign?.transactions ?? [];
 
     if (hasTransactionsToSign) {
+      if (transactionsToSign?.customTransactionInformation.preventNonceUpdate) {
+        setPreventNonceUpdate(true);
+        setHasTransactions(hasTransactionsToSign);
+        setTransactions(transactionsWithFixedNonce);
+
+        return;
+      }
+
       const transactionsWithIncrementalNonces = await setTransactionNonces(
         transactionsWithFixedNonce
       );
+
       setTransactions(transactionsWithIncrementalNonces);
     }
 
@@ -86,6 +96,7 @@ export const useSignTransactionsCommonData = () => {
     onAbort,
     setError,
     hasTransactions,
+    preventNonceUpdate,
     transactionsToSign: transactionsToSign
       ? {
           ...transactionsToSign,

--- a/src/services/transactions/sendTransactions.ts
+++ b/src/services/transactions/sendTransactions.ts
@@ -16,7 +16,8 @@ export async function sendTransactions({
   completedTransactionsDelay,
   sessionInformation,
   skipGuardian,
-  minGasLimit
+  minGasLimit,
+  preventNonceUpdate
 }: SendTransactionsPropsType): Promise<SendTransactionReturnType> {
   try {
     const transactionsPayload = Array.isArray(transactions)
@@ -44,7 +45,8 @@ export async function sendTransactions({
         completedTransactionsDelay,
         sessionInformation,
         skipGuardian,
-        signWithoutSending
+        signWithoutSending,
+        preventNonceUpdate
       }
     });
   } catch (err) {

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -139,6 +139,7 @@ export interface SendTransactionsPropsType {
   transactionsDisplayInfo: TransactionsDisplayInfoType;
   minGasLimit?: number;
   sessionInformation?: any;
+  preventNonceUpdate?: boolean;
 }
 
 export interface SignTransactionsPropsType {
@@ -210,6 +211,13 @@ export interface CustomTransactionInformation {
    * If true, the change guardian action will not trigger transaction version update
    */
   skipGuardian?: boolean;
+  /**
+   * If true, the nonce will not be updated before signing
+   * because the nonce is already set in the transaction
+   * It is usually true when signing multiple transactions from web wallet sign hook
+   * and all transactions have their nonce specified
+   */
+  preventNonceUpdate?: boolean;
 }
 
 export interface SendTransactionReturnType {


### PR DESCRIPTION
### Issue
Duplicate signatures appear after signing batch transactions with web wallet

### Reproduce
Issue exists on version `2.13.3` of sdk-dapp.

### Root cause
The `nonce` of each transaction to sign was updated during signing with web wallet

### Fix
Prevent updating the `nonce` when signing multiple transactions with web wallet (or when the flag `preventNonceUpdate` is present).

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
