### PR TITLE
[+] Improve transaction nonce update management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[v2.13.4]](https://github.com/multiversx/mx-sdk-dapp/pull/781)] - 2023-05-12
-- [Added flag to prevent updating nonce when signing transactions](https://github.com/multiversx/mx-sdk-dapp/pull/780)
+## [[v2.13.4]](https://github.com/multiversx/mx-sdk-dapp/pull/782)] - 2023-05-12
+- [Improve transaction nonce update management](https://github.com/multiversx/mx-sdk-dapp/pull/781)
+- [Prevent updating transaction nonce during signing if nonce is present](https://github.com/multiversx/mx-sdk-dapp/pull/780)
 
 ## [[v2.13.3]](https://github.com/multiversx/mx-sdk-dapp/pull/773)] - 2023-05-10
 - [Stop ledger double signing before leaving sign screen to 2FA hook](https://github.com/multiversx/mx-sdk-dapp/pull/777)

--- a/src/services/transactions/sendTransactions.ts
+++ b/src/services/transactions/sendTransactions.ts
@@ -16,8 +16,7 @@ export async function sendTransactions({
   completedTransactionsDelay,
   sessionInformation,
   skipGuardian,
-  minGasLimit,
-  preventNonceUpdate
+  minGasLimit
 }: SendTransactionsPropsType): Promise<SendTransactionReturnType> {
   try {
     const transactionsPayload = Array.isArray(transactions)
@@ -45,8 +44,7 @@ export async function sendTransactions({
         completedTransactionsDelay,
         sessionInformation,
         skipGuardian,
-        signWithoutSending,
-        preventNonceUpdate
+        signWithoutSending
       }
     });
   } catch (err) {

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -139,7 +139,6 @@ export interface SendTransactionsPropsType {
   transactionsDisplayInfo: TransactionsDisplayInfoType;
   minGasLimit?: number;
   sessionInformation?: any;
-  preventNonceUpdate?: boolean;
 }
 
 export interface SignTransactionsPropsType {
@@ -211,13 +210,6 @@ export interface CustomTransactionInformation {
    * If true, the change guardian action will not trigger transaction version update
    */
   skipGuardian?: boolean;
-  /**
-   * If true, the nonce will not be updated before signing
-   * because the nonce is already set in the transaction
-   * It is usually true when signing multiple transactions from web wallet sign hook
-   * and all transactions have their nonce specified
-   */
-  preventNonceUpdate?: boolean;
 }
 
 export interface SendTransactionReturnType {


### PR DESCRIPTION
### Feature
Moved nonce management within sdk-dapp. Update transaction nonce before signing only if nonce is missing

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
