### PR TITLE
Fix nonce management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fix nonce management](https://github.com/multiversx/mx-sdk-dapp/pull/788)
 - [Guarded account `gasLimit` update in `s` helper](https://github.com/multiversx/mx-sdk-dapp/pull/789)
 - [Added flag `preventNonceUpdate` to prevent nonce update](https://github.com/multiversx/mx-sdk-dapp/pull/786)
 

--- a/src/hooks/transactions/helpers/setTransactionNonces.ts
+++ b/src/hooks/transactions/helpers/setTransactionNonces.ts
@@ -1,0 +1,22 @@
+import { Transaction } from '@multiversx/sdk-core';
+
+export const setTransactionNonces = (
+  latestNonce: number,
+  transactions: Array<Transaction>
+): Array<Transaction> => {
+  if (transactions.length === 0) {
+    return transactions;
+  }
+
+  return transactions.map((tx: Transaction, index: number) => {
+    const nextNonce = latestNonce + index;
+
+    const txNonce = tx.getNonce().valueOf();
+    // stop replacing nonce if transaction is configured with a higher nonce than the existing one
+    const computedNonce = txNonce > nextNonce ? txNonce : nextNonce;
+
+    tx.setNonce(computedNonce);
+
+    return tx;
+  });
+};

--- a/src/hooks/transactions/helpers/useSetTransactionNonces.ts
+++ b/src/hooks/transactions/helpers/useSetTransactionNonces.ts
@@ -12,11 +12,13 @@ const setTransactionNonces = (
     return transactions;
   }
 
-  const firstTxNonce = transactions[0].getNonce().valueOf();
-  const computedNonce = firstTxNonce > latestNonce ? firstTxNonce : latestNonce;
-
   return transactions.map((tx: Transaction, index: number) => {
-    tx.setNonce(computedNonce + index);
+    const nextNonce = latestNonce + index;
+
+    const txNonce = tx.getNonce().valueOf();
+    const computedNonce = txNonce > nextNonce ? txNonce : nextNonce;
+
+    tx.setNonce(computedNonce);
 
     return tx;
   });

--- a/src/hooks/transactions/helpers/useSetTransactionNonces.ts
+++ b/src/hooks/transactions/helpers/useSetTransactionNonces.ts
@@ -3,26 +3,7 @@ import { useSelector } from 'reduxStore/DappProviderContext';
 import { addressSelector } from 'reduxStore/selectors';
 import { getAccount } from 'utils/account/getAccount';
 import { getLatestNonce } from 'utils/account/getLatestNonce';
-
-const setTransactionNonces = (
-  latestNonce: number,
-  transactions: Array<Transaction>
-): Array<Transaction> => {
-  if (transactions.length === 0) {
-    return transactions;
-  }
-
-  return transactions.map((tx: Transaction, index: number) => {
-    const nextNonce = latestNonce + index;
-
-    const txNonce = tx.getNonce().valueOf();
-    const computedNonce = txNonce > nextNonce ? txNonce : nextNonce;
-
-    tx.setNonce(computedNonce);
-
-    return tx;
-  });
-};
+import { setTransactionNonces } from './setTransactionNonces';
 
 export const useSetTransactionNonces = () => {
   const address = useSelector(addressSelector);

--- a/src/hooks/transactions/helpers/useSetTransactionNonces.ts
+++ b/src/hooks/transactions/helpers/useSetTransactionNonces.ts
@@ -8,8 +8,15 @@ const setTransactionNonces = (
   latestNonce: number,
   transactions: Array<Transaction>
 ): Array<Transaction> => {
+  if (transactions.length === 0) {
+    return transactions;
+  }
+
+  const firstTxNonce = transactions[0].getNonce().valueOf();
+  const computedNonce = firstTxNonce > latestNonce ? firstTxNonce : latestNonce;
+
   return transactions.map((tx: Transaction, index: number) => {
-    tx.setNonce(latestNonce + index);
+    tx.setNonce(computedNonce + index);
 
     return tx;
   });

--- a/src/hooks/transactions/tests/setTransactionNonces.test.ts
+++ b/src/hooks/transactions/tests/setTransactionNonces.test.ts
@@ -1,0 +1,91 @@
+import { GAS_LIMIT, GAS_PRICE } from 'constants/index';
+import { newTransaction } from 'models/newTransaction';
+import { TransactionServerStatusesEnum } from 'types/enums.types';
+import { setTransactionNonces } from '../helpers/setTransactionNonces';
+
+const mockedTransactions = [
+  {
+    nonce: 0,
+    hash: '5996572de1fc5df2c456602467e8cc1a446b8145ae79df8f6c670e0732ab3b04',
+    status: TransactionServerStatusesEnum.pending,
+    value: '10',
+    receiver: 'erd1zwq3qaa3vk5suenlkj4cf0ullwefa6h3n2394k25pxv4sz0pwhhsj9u9vk',
+    sender: 'erd1zwq3qaa3vk5suenlkj4cf0ullwefa6h3n2394k25pxv4sz0pwhhsj9u9vk',
+    data: '',
+    chainID: 'D',
+    version: 1,
+    gasPrice: GAS_PRICE,
+    gasLimit: GAS_LIMIT
+  },
+  {
+    nonce: 0,
+    hash: '8970fe5f5548caa994e495798ee1874b07f4ac2156d6a3a9636f450211350784',
+    status: TransactionServerStatusesEnum.fail,
+    value: '10',
+    receiver: 'erd1zwq3qaa3vk5suenlkj4cf0ullwefa6h3n2394k25pxv4sz0pwhhsj9u9vk',
+    sender: 'erd1zwq3qaa3vk5suenlkj4cf0ullwefa6h3n2394k25pxv4sz0pwhhsj9u9vk',
+    data: '',
+    chainID: 'D',
+    version: 1,
+    gasPrice: GAS_PRICE,
+    gasLimit: GAS_LIMIT
+  },
+  {
+    nonce: 0,
+    hash: 'd4d84be4aa09cf5d45f79ffed87c971e5d883e7581d31e00d585f65b2da0564d',
+    status: TransactionServerStatusesEnum.pending,
+    value: '10',
+    receiver: 'erd1zwq3qaa3vk5suenlkj4cf0ullwefa6h3n2394k25pxv4sz0pwhhsj9u9vk',
+    sender: 'erd1zwq3qaa3vk5suenlkj4cf0ullwefa6h3n2394k25pxv4sz0pwhhsj9u9vk',
+    data: '',
+    chainID: 'D',
+    version: 1,
+    gasPrice: GAS_PRICE,
+    gasLimit: GAS_LIMIT
+  }
+];
+
+describe('setTransactionNonces', () => {
+  it('should return empty array if transactions array is empty', () => {
+    const latestNonce = 123;
+
+    const result = setTransactionNonces(latestNonce, []);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should set nonces correctly for non-empty transactions array', () => {
+    const latestNonce = 123;
+    const transactions = mockedTransactions.map((tx) => {
+      tx.nonce = 0;
+      const newTx = newTransaction(tx);
+      newTx.setNonce = jest.fn();
+      return newTx;
+    });
+
+    const result = setTransactionNonces(latestNonce, transactions);
+
+    expect(transactions[0].setNonce).toHaveBeenCalledWith(123);
+    expect(transactions[1].setNonce).toHaveBeenCalledWith(124);
+    expect(transactions[2].setNonce).toHaveBeenCalledWith(125);
+    expect(result).toEqual(transactions);
+  });
+
+  it('should handle transactions with higher nonces correctly', () => {
+    const latestNonce = 123;
+
+    const transactions = mockedTransactions.map((tx, i) => {
+      tx.nonce = 125 + i;
+      const newTx = newTransaction(tx);
+      newTx.setNonce = jest.fn();
+      return newTx;
+    });
+
+    const result = setTransactionNonces(latestNonce, transactions);
+
+    expect(transactions[0].setNonce).toHaveBeenCalledWith(125);
+    expect(transactions[1].setNonce).toHaveBeenCalledWith(126);
+    expect(transactions[2].setNonce).toHaveBeenCalledWith(127);
+    expect(result).toEqual(transactions);
+  });
+});

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -119,11 +119,6 @@ export const useSignTransactions = () => {
     sessionId: string,
     callbackRoute = ''
   ) => {
-    console.log('signWithWallet - abc', {
-      transactions,
-      sessionId
-    });
-
     const urlParams = { [WALLET_SIGN_SESSION]: sessionId };
     let callbackUrl = callbackRoute;
 

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -119,6 +119,11 @@ export const useSignTransactions = () => {
     sessionId: string,
     callbackRoute = ''
   ) => {
+    console.log('signWithWallet - abc', {
+      transactions,
+      sessionId
+    });
+
     const urlParams = { [WALLET_SIGN_SESSION]: sessionId };
     let callbackUrl = callbackRoute;
 

--- a/src/hooks/transactions/useSignTransactionsCommonData.tsx
+++ b/src/hooks/transactions/useSignTransactionsCommonData.tsx
@@ -27,7 +27,6 @@ export const useSignTransactionsCommonData = () => {
   const [error, setError] = useState<string | null>(null);
   const [hasTransactions, setHasTransactions] = useState<boolean>();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [preventNonceUpdate, setPreventNonceUpdate] = useState<boolean>(false);
 
   const setTransactionNonces = useSetTransactionNonces();
   const transactionsToSign = useSelector(transactionsToSignSelector);
@@ -40,14 +39,6 @@ export const useSignTransactionsCommonData = () => {
     const transactionsWithFixedNonce = transactionsToSign?.transactions ?? [];
 
     if (hasTransactionsToSign) {
-      if (transactionsToSign?.customTransactionInformation.preventNonceUpdate) {
-        setPreventNonceUpdate(true);
-        setHasTransactions(hasTransactionsToSign);
-        setTransactions(transactionsWithFixedNonce);
-
-        return;
-      }
-
       const transactionsWithIncrementalNonces = await setTransactionNonces(
         transactionsWithFixedNonce
       );
@@ -96,7 +87,6 @@ export const useSignTransactionsCommonData = () => {
     onAbort,
     setError,
     hasTransactions,
-    preventNonceUpdate,
     transactionsToSign: transactionsToSign
       ? {
           ...transactionsToSign,

--- a/src/services/transactions/sendTransactions.ts
+++ b/src/services/transactions/sendTransactions.ts
@@ -16,8 +16,7 @@ export async function sendTransactions({
   completedTransactionsDelay,
   sessionInformation,
   skipGuardian,
-  minGasLimit,
-  preventNonceUpdate
+  minGasLimit
 }: SendTransactionsPropsType): Promise<SendTransactionReturnType> {
   try {
     const transactionsPayload = Array.isArray(transactions)
@@ -45,8 +44,7 @@ export async function sendTransactions({
         completedTransactionsDelay,
         sessionInformation,
         skipGuardian,
-        signWithoutSending,
-        preventNonceUpdate
+        signWithoutSending
       }
     });
   } catch (err) {

--- a/src/services/transactions/transformAndSignTransactions.ts
+++ b/src/services/transactions/transformAndSignTransactions.ts
@@ -15,7 +15,7 @@ enum ErrorCodesEnum {
   'unknownError' = 'Unknown Error. Please check the transactions and try again'
 }
 
-// TODO: replace with new erdjs function
+// TODO: add guarded account gas limit
 function calculateGasLimit(data?: string) {
   const bNconfigGasLimit = new BigNumber(GAS_LIMIT);
   const bNgasPerDataByte = new BigNumber(GAS_PER_DATA_BYTE);
@@ -44,7 +44,8 @@ export async function transformAndSignTransactions({
       gasPrice = GAS_PRICE,
       gasLimit = calculateGasLimit(tx.data),
       guardian,
-      guardianSignature
+      guardianSignature,
+      nonce: txNonce = 0
     } = tx;
     let validatedReceiver = receiver;
 
@@ -55,6 +56,8 @@ export async function transformAndSignTransactions({
       throw ErrorCodesEnum.invalidReceiver;
     }
 
+    const computedNonce = txNonce > nonce ? txNonce : nonce;
+
     const storeChainId = chainIDSelector(store.getState()).valueOf().toString();
     const transactionsChainId = chainID || storeChainId;
     return newTransaction({
@@ -63,7 +66,7 @@ export async function transformAndSignTransactions({
       data,
       gasPrice,
       gasLimit: Number(gasLimit),
-      nonce: Number(nonce.valueOf().toString()),
+      nonce: Number(computedNonce.valueOf().toString()),
       sender: new Address(address).hex(),
       chainID: transactionsChainId,
       version,

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -109,6 +109,7 @@ export interface SimpleTransactionType {
   options?: number;
   guardian?: string;
   guardianSignature?: string;
+  nonce?: number;
 }
 
 export interface TransactionsDisplayInfoType {
@@ -139,7 +140,6 @@ export interface SendTransactionsPropsType {
   transactionsDisplayInfo: TransactionsDisplayInfoType;
   minGasLimit?: number;
   sessionInformation?: any;
-  preventNonceUpdate?: boolean;
 }
 
 export interface SignTransactionsPropsType {
@@ -211,13 +211,6 @@ export interface CustomTransactionInformation {
    * If true, the change guardian action will not trigger transaction version update
    */
   skipGuardian?: boolean;
-  /**
-   * If true, the nonce will not be updated before signing
-   * because the nonce is already set in the transaction
-   * It is usually true when signing multiple transactions from web wallet sign hook
-   * and all transactions have their nonce specified
-   */
-  preventNonceUpdate?: boolean;
 }
 
 export interface SendTransactionReturnType {


### PR DESCRIPTION
### Issue
Incorrect nonce management on signing batch transactions with web wallet
### Reproduce
Issue exists on version `2.` of sdk-dapp.

### Root cause
WebWallet dApp doesn't know what the client dApp will do with the signed transactions (will send the signed transactions or not). Then, when a set of transactions arrives in the web wallet to be signed,  the web wallet takes the current account nonce from the store and computes the transactions nonces related to this. If you send the next batch (the previous one has not been executed yet) the nonce from the account is the same, then the next batch will consider the same nonce (account nonce) and will provide the transactions signed with a wrong nonce to the client dApp.
### Fix

### Additional changes
- remove unused `preventNonceUpdate`
### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
