### PR TITLE
Guarded account gas Limit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Guarded account `gasLimit` update in `s` helper](https://github.com/multiversx/mx-sdk-dapp/pull/789)
 - [Added flag `preventNonceUpdate` to prevent nonce update](https://github.com/multiversx/mx-sdk-dapp/pull/786)
 
 ## [[v2.13.5]](https://github.com/multiversx/mx-sdk-dapp/pull/784)] - 2023-05-13

--- a/src/services/transactions/transformAndSignTransactions.ts
+++ b/src/services/transactions/transformAndSignTransactions.ts
@@ -28,7 +28,9 @@ function calculateGasLimit({
   isGuarded?: boolean;
 }) {
   const guardedAccountGasLimit = isGuarded ? EXTRA_GAS_LIMIT_GUARDED_TX : 0;
-  const bNconfigGasLimit = new BigNumber(GAS_LIMIT + guardedAccountGasLimit);
+  const bNconfigGasLimit = new BigNumber(GAS_LIMIT).plus(
+    guardedAccountGasLimit
+  );
   const bNgasPerDataByte = new BigNumber(GAS_PER_DATA_BYTE);
   const bNgasValue = data
     ? bNgasPerDataByte.times(Buffer.from(data).length)


### PR DESCRIPTION
### Issue
- new transaction was not taking into account gas limit for guarded accounts

### Reproduce
Issue exists on version `2.13.5` of sdk-dapp.


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
