### PR TITLE
Updated default title logic

### DIFF
--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
@@ -96,12 +96,12 @@ export const SignStep = (props: SignStepType) => {
   const defaultSignTitle =
     allTransactions.length > 1
       ? `Signing Transaction ${currentStep + 1} of ${allTransactions.length}`
-      : 'Sign Transaction';
+      : title || 'Sign Transaction';
 
   const isGuardianScreenVisible = GuardianScreen && showGuardianScreen;
   const signFlowTitle = isGuardianScreenVisible
     ? 'Verify Guardian'
-    : title || defaultSignTitle;
+    : defaultSignTitle;
 
   const steps: ProgressHeaderPropsType['steps'] = [
     {


### PR DESCRIPTION
### Issue/Feature
The default title property passed to the `SignStep` component would override the logic of showing the dynamic steps' indexing. 

### Reproduce
Issue exists on version `2.14.2` of sdk-dapp.


### Fix
Moved the logic to only override when there's only one transaction to sign.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
