### PR TITLE
Fix batch transactions state after sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix batch transactions payload after sending](https://github.com/multiversx/mx-sdk-dapp/pull/808)
+
 ## [[v2.14.2]](https://github.com/multiversx/mx-sdk-dapp/pull/806)] - 2023-05-26
 
 - [Fix/window location for RN](https://github.com/multiversx/mx-sdk-dapp/pull/805)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Fix batch transactions payload after sending](https://github.com/multiversx/mx-sdk-dapp/pull/808)
+- [Fix batch transactions state after sending](https://github.com/multiversx/mx-sdk-dapp/pull/808)
 
 - [Fixed default sign step title override](https://github.com/multiversx/mx-sdk-dapp/pull/807)
 

--- a/src/hooks/transactions/batch/useSendBatchTransactions.ts
+++ b/src/hooks/transactions/batch/useSendBatchTransactions.ts
@@ -10,7 +10,10 @@ import {
   sendBatchTransactions,
   SendBatchTransactionsPropsType
 } from 'services/transactions/sendBatchTransactions';
-import { TransactionBatchStatusesEnum } from 'types/enums.types';
+import {
+  TransactionBatchStatusesEnum,
+  TransactionServerStatusesEnum
+} from 'types/enums.types';
 import { BatchTransactionStatus } from 'types/serverTransactions.types';
 import { sequentialToFlatArray } from 'utils/transactions/batch/sequentialToFlatArray';
 
@@ -33,13 +36,19 @@ export const useSendBatchTransactions = () => {
         };
 
         dispatch(setTxSubmittedModal(submittedModalPayload));
+
+        const transactions = sequentialToFlatArray({
+          transactions: params.transactions
+        }).map((transaction) => ({
+          ...transaction,
+          status: TransactionServerStatusesEnum.pending
+        }));
+
         dispatch(
           updateSignedTransactions({
             sessionId: params.sessionId,
             status: TransactionBatchStatusesEnum.sent,
-            transactions: sequentialToFlatArray({
-              transactions: data.transactions
-            })
+            transactions
           })
         );
       }
@@ -53,8 +62,7 @@ export const useSendBatchTransactions = () => {
 
       if (Boolean(error) || !isBatchStatusValid) {
         console.error('Unable to send batch transactions');
-        const batchId = data?.id ?? '';
-        removeBatchTransactions(batchId);
+        removeBatchTransactions(data?.id ?? '');
       }
 
       return response;


### PR DESCRIPTION
### Issue
The batch transactions state is wrong after sending, causing missing tx hash on tracking
### Reproduce
Issue exists on version `2.14.2` of sdk-dapp.

### Root cause

### Fix
The payload has to be defined using the already signed transactions from the batch
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
