### PR TITLE
Fix NextJs issue with redux-persist - could not load the children

### DIFF
--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -16,21 +16,25 @@ import {
   IDappProvider
 } from 'types';
 import { logout } from 'utils/logout';
+import { isWindowAvailable } from '../utils';
 
 export interface AppInitializerPropsType {
   customNetworkConfig?: CustomNetworkType;
-  children: any;
   externalProvider?: IDappProvider;
   environment: EnvironmentsEnum;
   dappConfig?: DappConfigType;
 }
 
-export function AppInitializer({
+export interface AppInitializerComponentPropsType
+  extends AppInitializerPropsType {
+  children?: any;
+}
+
+export const useAppInitializer = ({
   customNetworkConfig = {},
-  children,
   environment,
   dappConfig
-}: AppInitializerPropsType) {
+}: AppInitializerPropsType) => {
   const [initialized, setInitialized] = useState(false);
   const account = useGetAccountInfo();
   const isLoginSessionInvalid = useSelector(isLoginSessionInvalidSelector);
@@ -96,6 +100,25 @@ export function AppInitializer({
       logout(logoutRoute);
     }
   }, [isLoginSessionInvalid, account.address, logoutRoute]);
+
+  return { initialized };
+};
+
+export function AppInitializer({
+  customNetworkConfig = {},
+  children,
+  environment,
+  dappConfig
+}: AppInitializerComponentPropsType) {
+  const { initialized } = useAppInitializer({
+    customNetworkConfig,
+    environment,
+    dappConfig
+  });
+
+  if (!isWindowAvailable()) {
+    return <>{children}</>;
+  }
 
   return initialized ? <>{children}</> : null;
 }

--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -15,8 +15,8 @@ import {
   EnvironmentsEnum,
   IDappProvider
 } from 'types';
+import { isWindowAvailable } from 'utils/isWindowAvailable';
 import { logout } from 'utils/logout';
-import { isWindowAvailable } from '../utils';
 
 export interface AppInitializerPropsType {
   customNetworkConfig?: CustomNetworkType;

--- a/src/wrappers/AuthenticatedRoutesWrapper/AuthenticatedRoutesWrapper.tsx
+++ b/src/wrappers/AuthenticatedRoutesWrapper/AuthenticatedRoutesWrapper.tsx
@@ -27,7 +27,14 @@ export const AuthenticatedRoutesWrapper = ({
 
   const walletLogin = useSelector(walletLoginSelector);
 
-  const isOnAuthenticatedRoute = matchRoute(routes, window?.location.pathname);
+  const getLocationPathname = () => {
+    if (typeof window === 'undefined') {
+      return '';
+    }
+    return window.location.pathname;
+  };
+
+  const isOnAuthenticatedRoute = matchRoute(routes, getLocationPathname());
 
   const shouldRedirect =
     isOnAuthenticatedRoute && !isLoggedIn && walletLogin == null;

--- a/src/wrappers/DappProvider/DappProvider.tsx
+++ b/src/wrappers/DappProvider/DappProvider.tsx
@@ -50,18 +50,20 @@ export const DappProvider = ({
   return (
     <Provider context={DappCoreContext} store={store}>
       <PersistGate persistor={persistor} loading={null}>
-        <AppInitializer
-          environment={environment as EnvironmentsEnum}
-          customNetworkConfig={customNetworkConfig}
-          dappConfig={dappConfig}
-        >
-          <ProviderInitializer />
-          <CustomComponents
-            customComponents={customComponents}
-            enableBatchTransactions={enableBatchTransactions}
-          />
-          {children}
-        </AppInitializer>
+        {() => (
+          <AppInitializer
+            environment={environment as EnvironmentsEnum}
+            customNetworkConfig={customNetworkConfig}
+            dappConfig={dappConfig}
+          >
+            <ProviderInitializer />
+            <CustomComponents
+              customComponents={customComponents}
+              enableBatchTransactions={enableBatchTransactions}
+            />
+            {children}
+          </AppInitializer>
+        )}
       </PersistGate>
     </Provider>
   );


### PR DESCRIPTION
### Issue

1. Using DappProvider in NextJs project introduces an SSR issue. NextJs was unable to render the children under the DappProvider because of react-redux Persistor. 
2. AppInitilizer under DappProvider does not allow SSC to be rendered

### Reproduce
Issue exists on version `2.14` of sdk-dapp.

### Root cause
React-redux Persistor
### Fix

1. Fix the redux-persist issue
2. Render children every time when a child is SSC

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
