### PR TITLE
Fix nextjs hydration issue (duplicate DOM nodes)

### DIFF
--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -15,7 +15,6 @@ import {
   EnvironmentsEnum,
   IDappProvider
 } from 'types';
-import { isWindowAvailable } from 'utils/isWindowAvailable';
 import { logout } from 'utils/logout';
 
 export interface UseAppInitializerPropsType {
@@ -109,15 +108,17 @@ export function AppInitializer({
   environment,
   dappConfig
 }: AppInitializerPropsType) {
+  const [content, setContent] = useState(children);
+
   const { initialized } = useAppInitializer({
     customNetworkConfig,
     environment,
     dappConfig
   });
 
-  if (!isWindowAvailable()) {
-    return children;
-  }
+  useEffect(() => {
+    setContent(() => (initialized ? children : null));
+  }, [initialized, children]);
 
-  return initialized ? children : null;
+  return content;
 }


### PR DESCRIPTION
### Issue
Because of DOM tree differences between SC (server component) and CC (client component), the hydration process failed introducing duplicate DOM nodes (the nodes from the SC and the nodes from the CC)

### Reproduce
Issue exists on version `2.14` of sdk-dapp.

### Root cause
Because of the hydration process failure, the next.js use a fallback mechanism that uses client-side rendering of all the components under the DappProvider

### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
