### PR TITLE
Updated the amount value to use the raw amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed miscalculation of USD value of amount in sign flow summary](https://github.com/multiversx/mx-sdk-dapp/pull/823)
+
 ## [[v2.14.7]](https://github.com/multiversx/mx-sdk-dapp/pull/821)] - 2023-06-07
+
 - [Fix nextjs hydration issue (duplicate DOM nodes)](https://github.com/multiversx/mx-sdk-dapp/pull/820)
 
 ## [[v2.14.6]](https://github.com/multiversx/mx-sdk-dapp/pull/819)] - 2023-06-06
+
 - [Fix children loading issue in NextJs when using DappProvider](https://github.com/multiversx/mx-sdk-dapp/pull/818)
 
 ## [[v2.14.5]](https://github.com/multiversx/mx-sdk-dapp/pull/814)] - 2023-06-01
+
 - [Added `data-testid` properties and improved `ConfirmAmount` component](https://github.com/multiversx/mx-sdk-dapp/pull/815)
 - [Added extraInfo param for generating nativeAuth token](https://github.com/multiversx/mx-sdk-dapp/pull/813)
 

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/SignStepBody.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/SignStepBody.tsx
@@ -80,15 +80,19 @@ export const SignStepBody = ({
       tokenId: nonce && nonce?.length > 0 ? nftId : tokenId
     });
 
-  const formattedAmount = formatAmount({
-    input: isTokenTransaction
-      ? amount
-      : currentTransaction.transaction.getValue().toString(),
-    decimals: isTokenTransaction ? tokenDecimals : Number(network.decimals),
-    digits: Number(network.digits),
-    showLastNonZeroDecimal: false,
-    addCommas: true
-  });
+  const getFormattedAmount = ({ addCommas }: { addCommas: boolean }) =>
+    formatAmount({
+      input: isTokenTransaction
+        ? amount
+        : currentTransaction.transaction.getValue().toString(),
+      decimals: isTokenTransaction ? tokenDecimals : Number(network.decimals),
+      digits: Number(network.digits),
+      showLastNonZeroDecimal: false,
+      addCommas
+    });
+
+  const formattedAmount = getFormattedAmount({ addCommas: true });
+  const rawAmount = getFormattedAmount({ addCommas: false });
 
   const scamReport = currentTransaction.receiverScamInfo;
   const classes = useSignStepsClasses(scamReport);
@@ -140,7 +144,8 @@ export const SignStepBody = ({
             <div className={styles.column}>
               <ConfirmAmount
                 tokenAvatar={tokenAvatar}
-                amount={shownAmount}
+                formattedAmount={shownAmount}
+                rawAmount={rawAmount}
                 token={token}
                 tokenType={isEgld ? egldLabel : type}
                 tokenPrice={tokenPrice}

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmAmount/ConfirmAmount.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmAmount/ConfirmAmount.tsx
@@ -8,7 +8,8 @@ import styles from './confirmAmountStyles.scss';
 
 export interface ConfirmAmountPropsType {
   token: string;
-  amount: string;
+  formattedAmount: string;
+  rawAmount: string;
   tokenAvatar?: string;
   tokenType: TokenAvatarPropsType['type'];
   tokenPrice?: number | null;
@@ -18,7 +19,8 @@ export const ConfirmAmount = ({
   token,
   tokenAvatar,
   tokenType,
-  amount,
+  formattedAmount,
+  rawAmount,
   tokenPrice
 }: ConfirmAmountPropsType) => {
   const isValidTokenPrice = tokenPrice != null;
@@ -32,14 +34,14 @@ export const ConfirmAmount = ({
         <TokenAvatar type={tokenType} avatar={tokenAvatar} />
 
         <div className={styles.value} data-testid='confirmAmount'>
-          {amount} <TokenDetails.Label token={token} />
+          {formattedAmount} <TokenDetails.Label token={token} />
         </div>
       </div>
 
       {isLoadingTokenPrice && <LoadingDots className={styles.price} />}
       {isValidTokenPrice && (
         <UsdValue
-          amount={amount}
+          amount={rawAmount}
           usd={tokenPrice}
           data-testid='confirmUsdValue'
           className={styles.price}

--- a/src/UI/UsdValue/UsdValue.tsx
+++ b/src/UI/UsdValue/UsdValue.tsx
@@ -30,6 +30,7 @@ export const UsdValue = ({
     decimals,
     addEqualSign: addEqualSign ?? true
   });
+
   const isAmountZero = `${amount}` === ZERO;
   const displayedValue = isAmountZero ? `= $${ZERO}` : value;
 


### PR DESCRIPTION
### Issue/Feature
Inserting a value too large that would contain a comma would break the algorithm that calculates the USD amount of a certain token transaction.

### Reproduce
Issue exists on version `2.14.7` of sdk-dapp.

### Root cause
The algorithm was using a formatted amount, used for display, instead of the raw amount that is suited for calculations.

### Fix
Separated the two and only kept the displaying value for display, and the raw amount for calculations.

### Contains breaking changes
[x] No
[] Yes

### Updated CHANGELOG
[] No
[x] Yes

### Testing
[x] User testing
[] Unit tests
