### PR TITLE
Fix ledger reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] 
-- [Fixed double setting of ledger provider on page reload](https://github.com/multiversx/mx-sdk-dapp/pull/825)
+- [Fixed double setting of ledger provider on page reload](https://github.com/multiversx/mx-sdk-dapp/pull/827)
 ## [[v2.14.9]](https://github.com/multiversx/mx-sdk-dapp/pull/826)] - 2023-06-08
 - [Added datatestids to login buttons](https://github.com/multiversx/mx-sdk-dapp/pull/825)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] 
+- [Fixed double setting of ledger provider on page reload](https://github.com/multiversx/mx-sdk-dapp/pull/825)
 ## [[v2.14.9]](https://github.com/multiversx/mx-sdk-dapp/pull/826)] - 2023-06-08
 - [Added datatestids to login buttons](https://github.com/multiversx/mx-sdk-dapp/pull/825)
 

--- a/src/components/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer.tsx
@@ -48,6 +48,8 @@ import { logout } from 'utils/logout';
 import { parseNavigationParams } from 'utils/parseNavigationParams';
 import { useWebViewLogin } from '../hooks/login/useWebViewLogin';
 
+let initalizingLedger = false;
+
 export function ProviderInitializer() {
   const network = useSelector(networkSelector);
   const walletConnectLogin = useSelector(walletConnectLoginSelector);
@@ -280,13 +282,15 @@ export function ProviderInitializer() {
     }
   }
 
-  function initializeProvider() {
-    if (loginMethod == null) {
+  async function initializeProvider() {
+    if (loginMethod == null || initalizingLedger) {
       return;
     }
     switch (loginMethod) {
       case LoginMethodsEnum.ledger: {
-        setLedgerProvider();
+        initalizingLedger = true;
+        await setLedgerProvider();
+        initalizingLedger = false;
         break;
       }
 


### PR DESCRIPTION
### Issue
- Ledger HwApp losing connection with ledger on page reload
### Reproduce
Issue exists on version `2.14.9` of sdk-dapp.

### Root cause
ProviderInitializer setting ledger provider twice 
### Fix
Create a local variable to prevent double setting of HWApp

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
