### PR TITLE
Add-Server-Tx-Tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.14.11]](https://github.com/multiversx/mx-sdk-dapp/pull/829)] - 2023-06-09
+- [Add-Server-Tx-Tracking](https://github.com/multiversx/mx-sdk-dapp/pull/829)
+
 ## [[v2.14.10]](https://github.com/multiversx/mx-sdk-dapp/pull/828)] - 2023-06-09
 - [Fix infinite page reload using nextjs navigation](https://github.com/multiversx/mx-sdk-dapp/pull/822)
 

--- a/src/services/transactions/trackServerTransactions.ts
+++ b/src/services/transactions/trackServerTransactions.ts
@@ -1,0 +1,105 @@
+import {
+  NotificationTypesEnum,
+  SendTransactionReturnType,
+  SignedTransactionType,
+  TrackTransactionsPropsType,
+  TransactionBatchStatusesEnum,
+  TransactionServerStatusesEnum
+} from 'types';
+import { chainIDSelector } from '../../reduxStore/selectors';
+import {
+  moveTransactionsToSignedState,
+  setNotificationModal,
+  setTransactionsDisplayInfo,
+  updateSignedTransactions
+} from '../../reduxStore/slices';
+import { store } from '../../reduxStore/store';
+
+export async function trackServerTransactions({
+  transactions,
+  transactionsDisplayInfo,
+  redirectAfterSign = true,
+  completedTransactionsDelay,
+  sessionInformation
+}: TrackTransactionsPropsType): Promise<SendTransactionReturnType> {
+  const appState = store.getState();
+  const sessionId = Date.now().toString();
+  const storeChainId = chainIDSelector(appState);
+  try {
+    const transactionsPayload = Array.isArray(transactions)
+      ? transactions
+      : [transactions];
+
+    const signedTransactions = transactionsPayload.filter(
+      (transaction) => transaction.signature
+    );
+
+    if (!signedTransactions) {
+      const notificationPayload = {
+        type: NotificationTypesEnum.warning,
+        iconClassName: 'text-warning',
+        title: 'No pre-signed transaction sent',
+        description:
+          'The application tried to send transactions without signature'
+      };
+      store.dispatch(setNotificationModal(notificationPayload));
+      return { error: 'Missing Transactions Signatures', sessionId: null };
+    }
+
+    const transactionsToTrack: SignedTransactionType[] = [];
+
+    for (const tx of signedTransactions) {
+      const signedTx: SignedTransactionType = {
+        hash: tx.txHash,
+        status: TransactionServerStatusesEnum.pending,
+        inTransit: tx.inTransit,
+        nonce: tx.nonce,
+        value: tx.value,
+        receiver: tx.receiver,
+        sender: tx.sender,
+        gasPrice: tx.gasPrice,
+        gasLimit: tx.gasLimit,
+        data: tx.data,
+        chainID: storeChainId,
+        version: 1,
+        signature: tx.signature
+      };
+
+      transactionsToTrack.push({
+        ...signedTx,
+        status: TransactionServerStatusesEnum.pending,
+        customTransactionInformation: {
+          redirectAfterSign,
+          completedTransactionsDelay,
+          sessionInformation,
+          skipGuardian: true,
+          signWithoutSending: false
+        }
+      });
+    }
+
+    store.dispatch(
+      moveTransactionsToSignedState({
+        sessionId,
+        status: TransactionBatchStatusesEnum.sent,
+        transactions: transactionsToTrack
+      })
+    );
+
+    store.dispatch(
+      updateSignedTransactions({
+        sessionId,
+        status: TransactionBatchStatusesEnum.sent,
+        transactions: transactionsToTrack
+      })
+    );
+    store.dispatch(
+      setTransactionsDisplayInfo({ sessionId, transactionsDisplayInfo })
+    );
+  } catch (error) {
+    console.error('error tracking transaction', error as any);
+    return { error: error as any, sessionId: null };
+  }
+
+  return { sessionId };
+}

--- a/src/services/transactions/trackTransactions.ts
+++ b/src/services/transactions/trackTransactions.ts
@@ -1,0 +1,23 @@
+import { SendTransactionReturnType, TrackTransactionsPropsType } from 'types';
+import { trackServerTransactions } from './trackServerTransactions';
+
+export async function trackTransactions({
+  transactions,
+  transactionsDisplayInfo,
+  sessionInformation
+}: TrackTransactionsPropsType): Promise<SendTransactionReturnType> {
+  try {
+    const transactionsPayload = Array.isArray(transactions)
+      ? transactions
+      : [transactions];
+
+    return trackServerTransactions({
+      transactions: transactionsPayload,
+      transactionsDisplayInfo,
+      sessionInformation
+    });
+  } catch (err) {
+    console.error('error tracking transaction', err as any);
+    return { error: err as any, sessionId: null };
+  }
+}

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -9,7 +9,7 @@ import type {
   TransactionServerStatusesEnum,
   TransactionTypesEnum
 } from './enums.types';
-import { BatchTransactionsResponseType } from './serverTransactions.types';
+import { BatchTransactionsResponseType, ServerTransactionType } from './serverTransactions.types';
 
 export interface TransactionsToSignType {
   transactions: IPlainTransactionObject[];
@@ -148,6 +148,15 @@ export interface SignTransactionsPropsType {
   callbackRoute?: string;
   transactionsDisplayInfo: TransactionsDisplayInfoType;
   customTransactionInformation: CustomTransactionInformation;
+}
+
+export interface TrackTransactionsPropsType {
+  transactions: ServerTransactionType | ServerTransactionType[];
+  redirectAfterSign?: boolean;
+  completedTransactionsDelay?: number;
+  callbackRoute?: string;
+  transactionsDisplayInfo: TransactionsDisplayInfoType;
+  sessionInformation?: any;
 }
 
 export interface ActiveLedgerTransactionType {


### PR DESCRIPTION
### Feature
Tracking external/blockchain transactions (that are not generated by auth user).

### Reproduce
Issue exists on version `2.` of sdk-dapp.

### Root cause
When building the relayed txs, the final transaction is sent by a different sender. We wanted to display the user the same tooltip as the tx tooltips that he signed.

### Fix

### Additional changes
Adding a tx service that will track an external tx and add it to the redux store.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
