### PR TITLE
Fix double signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fix double signing same transaction in SignStep](https://github.com/multiversx/mx-sdk-dapp/pull/822)
 
 ## [[v2.14.10]](https://github.com/multiversx/mx-sdk-dapp/pull/828)] - 2023-06-09
 - [Fix infinite page reload using nextjs navigation](https://github.com/multiversx/mx-sdk-dapp/pull/822)


### PR DESCRIPTION
### Issue
SignStep was allowing signing the same transaction twice if user was clicking too fast in signing wizard before transaction was able to load.

### Reproduce
Issue exists on version `2.14.10` of sdk-dapp.

### Root cause
Transaction loading was happening slower than current step loading

### Fix
Create a mapping object between transaction nonce and current step index


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
