### PR TITLE
Fix invalid network config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed possible invalid calls to network config endpoint](https://github.com/multiversx/mx-sdk-dapp/pull/830)
 ## [[v2.14.11]](https://github.com/multiversx/mx-sdk-dapp/pull/831)] - 2023-06-13
-- [Fix double signing same transaction in SignStep](https://github.com/multiversx/mx-sdk-dapp/pull/830)
+- [Fixed double signing same transaction in SignStep](https://github.com/multiversx/mx-sdk-dapp/pull/830)
 
 ## [[v2.14.10]](https://github.com/multiversx/mx-sdk-dapp/pull/828)] - 2023-06-09
-- [Fix infinite page reload using nextjs navigation](https://github.com/multiversx/mx-sdk-dapp/pull/822)
+- [Fixed infinite page reload using nextjs navigation](https://github.com/multiversx/mx-sdk-dapp/pull/822)
 
 ## [[v2.14.9]](https://github.com/multiversx/mx-sdk-dapp/pull/826)] - 2023-06-08
 - [Added datatestids to login buttons](https://github.com/multiversx/mx-sdk-dapp/pull/825)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Fixed possible invalid calls to network config endpoint](https://github.com/multiversx/mx-sdk-dapp/pull/830)
+- [Fixed possible invalid calls to network config endpoint](https://github.com/multiversx/mx-sdk-dapp/pull/832)
 ## [[v2.14.11]](https://github.com/multiversx/mx-sdk-dapp/pull/831)] - 2023-06-13
 - [Fixed double signing same transaction in SignStep](https://github.com/multiversx/mx-sdk-dapp/pull/830)
 

--- a/src/apiCalls/configuration/getNetworkConfig.ts
+++ b/src/apiCalls/configuration/getNetworkConfig.ts
@@ -3,8 +3,20 @@ import { NETWORK_CONFIG_ENDPOINT } from 'apiCalls/endpoints';
 import { getCleanApiAddress } from 'apiCalls/utils';
 import { ApiNetworkConfigType } from 'types';
 
+const urlIsValid = (url: string) => {
+  try {
+    return Boolean(new URL(url));
+  } catch {
+    return false;
+  }
+};
+
 export async function getNetworkConfigFromApi() {
   const apiAddress = getCleanApiAddress();
+
+  if (!urlIsValid(apiAddress)) {
+    return null;
+  }
 
   const configUrl = `${apiAddress}/${NETWORK_CONFIG_ENDPOINT}`;
 


### PR DESCRIPTION
### Issue
Network config calls in tests were failing due to invalid URL origin

### Reproduce
Issue exists on version `2.14.11` of sdk-dapp.

### Fix
- validate network URL before making network config calls

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
