### PR TITLE
Fix sign step transaction identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed SignStep loading button for multiEsdtTransfers](https://github.com/multiversx/mx-sdk-dapp/pull/834)
 
 ## [[v2.14.12]](https://github.com/multiversx/mx-sdk-dapp/pull/833)] - 2023-06-14
 - [Fixed possible invalid calls to network config endpoint](https://github.com/multiversx/mx-sdk-dapp/pull/832)

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
@@ -16,8 +16,6 @@ import styles from './signWithDeviceModalStyles.scss';
 
 export { SignStepType, SignStepInnerClassesType };
 
-console.log('\x1b[42m%s\x1b[0m', 11);
-
 export const SignStep = (props: SignStepType) => {
   const {
     onSignTransaction,

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
@@ -16,6 +16,8 @@ import styles from './signWithDeviceModalStyles.scss';
 
 export { SignStepType, SignStepInnerClassesType };
 
+console.log('\x1b[42m%s\x1b[0m', 11);
+
 export const SignStep = (props: SignStepType) => {
   const {
     onSignTransaction,
@@ -35,8 +37,8 @@ export const SignStep = (props: SignStepType) => {
 
   const [showGuardianScreen, setShowGuardianScreen] = useState(false);
 
-  // a unique mapping between nonce and step to prevent signing same transaction twice
-  const [nonceStepMap, setNonceStepMap] = useState<
+  // a unique mapping between nonce + data and step to prevent signing same transaction twice
+  const [nonceDataStepMap, setNonceDataStepMap] = useState<
     Record<number, number | undefined>
   >({});
 
@@ -45,25 +47,27 @@ export const SignStep = (props: SignStepType) => {
   }
 
   const currentNonce = currentTransaction.transaction.getNonce().valueOf();
+  const currentNonceData = `${currentNonce.toString()}_${
+    currentTransaction.transactionTokenInfo.multiTxData
+  }`;
 
   useEffect(() => {
-    const isCurrentNonceRegistered = Object.keys(nonceStepMap).includes(
-      currentNonce.toString()
-    );
+    const isCurrentNonceRegistered =
+      Object.keys(nonceDataStepMap).includes(currentNonceData);
     const isCurrentStepRegistered =
-      Object.values(nonceStepMap).includes(currentStep);
+      Object.values(nonceDataStepMap).includes(currentStep);
 
     if (isCurrentNonceRegistered || isCurrentStepRegistered) {
       return;
     }
 
-    setNonceStepMap((existing) => {
+    setNonceDataStepMap((existing) => {
       return {
         ...existing,
-        [currentNonce]: currentStep
+        [currentNonceData]: currentStep
       };
     });
-  }, [currentNonce, currentStep]);
+  }, [currentNonceData, currentStep]);
 
   const transactionData = currentTransaction.transaction.getData().toString();
 
@@ -144,7 +148,7 @@ export const SignStep = (props: SignStepType) => {
   const scamReport = currentTransaction.receiverScamInfo;
   const classes = useSignStepsClasses(scamReport);
 
-  const isSigningReady = nonceStepMap[currentNonce] === currentStep;
+  const isSigningReady = nonceDataStepMap[currentNonceData] === currentStep;
 
   return (
     <div


### PR DESCRIPTION
### Issue
Signing with ledger button frozen for multiEsdtTransfer transactions

### Reproduce
Issue exists on version `2.14.12` of sdk-dapp.

### Root cause
Nonce is the same at multiEsdtTransfer transactions

### Fix
Create an unique identifier from `nonce` and `transactionTokenInfo.multiTxData`

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
