### PR TITLE
[Testing] Axios instance

### DIFF
--- a/src/services/nativeAuth/tests/nativeAuth.test.ts
+++ b/src/services/nativeAuth/tests/nativeAuth.test.ts
@@ -24,12 +24,15 @@ describe('Native Auth', () => {
   let timestampSpy: jest.SpyInstance;
   const currentTimestamp = 1686847;
 
+  // Create and use the same instance of axios across all requests
+  const axiosAPI = axios.create();
+
   beforeEach(() => {
     timestampSpy = jest.spyOn(Date, 'now').mockReturnValue(currentTimestamp);
   });
 
   beforeAll(() => {
-    mock = new MockAdapter(axios);
+    mock = new MockAdapter(axiosAPI);
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Issue/Feature
Downgrading axios to 0.24.0 on @multiversx/sdk-native-auth-client would break tests in which requests would do 404.

### Reproduce
Issue exists on version `2.14.13` of sdk-dapp.

### Root cause

### Fix
Create a single instance of axios in order to be used across all requests.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[] Yes

### Testing
[x] User testing
[] Unit tests
