### PR TITLE
Fix failed wallet login attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [[v2.15.0]](https://github.com/multiversx/mx-sdk-dapp/pull/843)] - 2023-06-20
-- [Fix ledger init issue on Next.js](https://github.com/multiversx/mx-sdk-dapp/pull/842)
+- [Fixed AuthenticatedRoutesWrapper blocking render on failed wallet login attempt](https://github.com/multiversx/mx-sdk-dapp/pull/842)
+## [[v2.15.1]](https://github.com/multiversx/mx-sdk-dapp/pull/843)] - 2023-06-20
+- [Fixed ledger init issue on Next.js](https://github.com/multiversx/mx-sdk-dapp/pull/842)
 
 ## [[v2.15.0]](https://github.com/multiversx/mx-sdk-dapp/pull/835)] - 2023-06-19
 - [Added `on-pull-request.yml` script](https://github.com/multiversx/mx-sdk-dapp/pull/838)

--- a/src/utils/account/getAddress.tsx
+++ b/src/utils/account/getAddress.tsx
@@ -7,10 +7,9 @@ import {
 import { store } from 'reduxStore/store';
 import { LoginMethodsEnum } from 'types/enums.types';
 import { getIsProviderEqualTo } from 'utils/account/getIsProviderEqualTo';
-import { addressIsValid } from './addressIsValid';
+import { getSearchParamAddress } from './getSearchParamAddress';
 
 export function getAddress(): Promise<string> {
-  const search = window?.location.search;
   const appState = store.getState();
   const provider = getAccountProvider();
   const address = addressSelector(appState);
@@ -32,12 +31,9 @@ export function getAddress(): Promise<string> {
     !getIsProviderEqualTo(LoginMethodsEnum.extra)
     ? provider.getAddress()
     : new Promise((resolve) => {
-        if (walletLogin != null) {
-          const urlSearchParams = new URLSearchParams(search);
-          const params = Object.fromEntries(urlSearchParams as any);
-          if (addressIsValid(params.address)) {
-            resolve(params.address);
-          }
+        const searchParamAddress = getSearchParamAddress();
+        if (walletLogin != null && searchParamAddress) {
+          resolve(searchParamAddress);
         }
         if (loggedIn) {
           resolve(address);

--- a/src/utils/account/getSearchParamAddress.ts
+++ b/src/utils/account/getSearchParamAddress.ts
@@ -1,0 +1,12 @@
+import { addressIsValid } from './addressIsValid';
+
+export const getSearchParamAddress = () => {
+  const search = window?.location.search;
+  const urlSearchParams = new URLSearchParams(search);
+  const params = Object.fromEntries(urlSearchParams as any);
+  const address: string = params?.address;
+  if (addressIsValid(address)) {
+    return address;
+  }
+  return null;
+};

--- a/src/utils/account/index.ts
+++ b/src/utils/account/index.ts
@@ -1,4 +1,5 @@
 export * from './addressIsValid';
+export * from './getSearchParamAddress';
 export * from './getAccount';
 export * from './getAccountBalance';
 export * from './getAccountProviderType';

--- a/src/utils/account/tests/getSearchParamAddress.test.ts
+++ b/src/utils/account/tests/getSearchParamAddress.test.ts
@@ -1,0 +1,46 @@
+import { cleanup } from '@testing-library/react';
+import { testAddress } from '__mocks__';
+import { getSearchParamAddress } from '../getSearchParamAddress';
+
+const createMockLocation = (search: string) => {
+  global.window = Object.create(window);
+  Object.defineProperty(window, 'location', {
+    value: {
+      search
+    },
+    writable: true
+  });
+};
+
+describe('getSearchParamAddress', () => {
+  afterEach(cleanup);
+  it('should return the address if it is valid', () => {
+    createMockLocation(`?address=${testAddress}`);
+
+    const result = getSearchParamAddress();
+
+    expect(result).toBe(testAddress);
+  });
+
+  it('should return null if the address is invalid', () => {
+    createMockLocation('?address=invalidAddress');
+
+    const result = getSearchParamAddress();
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null if the address parameter is not provided', () => {
+    // Mock the window object and URLSearchParams
+    const mockLocation = {
+      search: ''
+    };
+    (global as any).window = {
+      location: mockLocation
+    };
+
+    const result = getSearchParamAddress();
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/wrappers/AuthenticatedRoutesWrapper/AuthenticatedRoutesWrapper.tsx
+++ b/src/wrappers/AuthenticatedRoutesWrapper/AuthenticatedRoutesWrapper.tsx
@@ -7,6 +7,7 @@ import {
 } from 'reduxStore/selectors';
 
 import { RouteType } from 'types';
+import { getSearchParamAddress } from 'utils/account/getSearchParamAddress';
 import { isWindowAvailable } from 'utils/isWindowAvailable';
 import { safeRedirect } from 'utils/redirect';
 import { matchRoute } from './helpers/matchRoute';
@@ -24,6 +25,7 @@ export const AuthenticatedRoutesWrapper = ({
   unlockRoute: string;
   onRedirect?: (unlockRoute?: string) => void;
 }) => {
+  const searchParamAddress = getSearchParamAddress();
   const isLoggedIn = useSelector(isLoggedInSelector);
 
   const isAccountLoading = useSelector(isAccountLoadingSelector);
@@ -45,7 +47,9 @@ export const AuthenticatedRoutesWrapper = ({
   const shouldRedirect =
     isOnAuthenticatedRoute && !isLoggedIn && walletLogin == null;
 
-  if (isAccountLoading || walletLogin) {
+  const isValidWalletLoginAttempt = walletLogin != null && searchParamAddress;
+
+  if (isAccountLoading || isValidWalletLoginAttempt) {
     return null;
   }
 


### PR DESCRIPTION
### Issue
Attempting a wallet login and pressing back was causing blank screen in multiple dapps

### Reproduce
Issue exists on version `2.15.1` of sdk-dapp.

### Root cause
AuthenticatedRoutesWrapper was blocking the render because of the `walletLogin` session flag.

### Fix
Take account of the address parameter present in URL


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
