### PR TITLE
Fix batch transactions status update when the WS response is received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix batch transactions status update when the WS response is received](https://github.com/multiversx/mx-sdk-dapp/pull/855)
+
 ## [[v2.16.0]](https://github.com/multiversx/mx-sdk-dapp/pull/849)] - 2023-06-28
 - [Added support for component injection into custom toasts](https://github.com/multiversx/mx-sdk-dapp/pull/848)
 

--- a/src/hooks/websocketListener/useInitializeWebsocketConnection.tsx
+++ b/src/hooks/websocketListener/useInitializeWebsocketConnection.tsx
@@ -17,9 +17,11 @@ const RECONNECTION_ATTEMPTS = 3;
 const RETRY_INTERVAL = 500;
 const MESSAGE_DELAY = 1000;
 const BATCH_UPDATED_EVENT = 'batchUpdated';
+const DISCONNECT = 'disconnect';
 
 export function useInitializeWebsocketConnection() {
-  const timeout = useRef<NodeJS.Timeout | null>(null);
+  const messageTimeout = useRef<NodeJS.Timeout | null>(null);
+  const batchTimeout = useRef<NodeJS.Timeout | null>(null);
 
   const { address } = useGetAccount();
 
@@ -28,19 +30,19 @@ export function useInitializeWebsocketConnection() {
   const { network } = useGetNetworkConfig();
 
   const handleMessageReceived = (message: string) => {
-    if (timeout.current) {
-      clearTimeout(timeout.current);
+    if (messageTimeout.current) {
+      clearTimeout(messageTimeout.current);
     }
-    timeout.current = setTimeout(() => {
+    messageTimeout.current = setTimeout(() => {
       dispatch(setWebsocketEvent(message));
     }, MESSAGE_DELAY);
   };
 
   const handleBatchUpdate = (data: BatchTransactionsWSResponseType) => {
-    if (timeout.current) {
-      clearTimeout(timeout.current);
+    if (batchTimeout.current) {
+      clearTimeout(batchTimeout.current);
     }
-    timeout.current = setTimeout(() => {
+    batchTimeout.current = setTimeout(() => {
       dispatch(setWebsocketBatchEvent(data));
     }, MESSAGE_DELAY);
   };
@@ -73,6 +75,12 @@ export function useInitializeWebsocketConnection() {
         websocketConnection.current.onAny(handleMessageReceived);
 
         websocketConnection.current.on(BATCH_UPDATED_EVENT, handleBatchUpdate);
+
+        websocketConnection.current.on(DISCONNECT, () => {
+          console.warn('Websocket disconnected. Trying to reconnect...');
+          websocketConnection.current?.close();
+          websocketConnection.current?.connect();
+        });
       },
       {
         retries: 2,
@@ -98,8 +106,8 @@ export function useInitializeWebsocketConnection() {
       websocketConnection.current?.close();
       websocketConnection.status =
         WebsocketConnectionStatusEnum.NOT_INITIALIZED;
-      if (timeout.current) {
-        clearTimeout(timeout.current);
+      if (messageTimeout.current) {
+        clearTimeout(messageTimeout.current);
       }
     };
   }, []);

--- a/src/hooks/websocketListener/useRegisterWebsocketListener.ts
+++ b/src/hooks/websocketListener/useRegisterWebsocketListener.ts
@@ -28,5 +28,5 @@ export function useRegisterWebsocketListener(
     if (data) {
       onBatchMessage?.(data);
     }
-  }, [onMessage, websocketBatchEvent]);
+  }, [onBatchMessage, websocketBatchEvent]);
 }


### PR DESCRIPTION
### Issue
Sometimes the toasts are not resolved accordingly with the response from the WS and are resolved by the fallback mechanism
### Reproduce
Issue exists on version `2.` of sdk-dapp.

### Root cause

### Fix
Fix WS reconnect issue and the way how the batch update status is handled
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
