### PR TITLE
Fix cancel transaction toast close behavior and add support for onClose handle on custom toasts

### DIFF
--- a/src/UI/SignTransactionsModals/components/TransactionStatusToast.tsx
+++ b/src/UI/SignTransactionsModals/components/TransactionStatusToast.tsx
@@ -52,10 +52,9 @@ export const TransactionStatusToast = ({
         dappConfig.cancelTransactionToastDuration ??
         CANCEL_TRANSACTION_TOAST_DEFAULT_DURATION,
       component: () => <StatusMessageComponent type={type} message={message} />,
+      onClose: () => onDelete(),
       icon: faWarning
     });
-
-    return () => onDelete();
   }, []);
 
   return null;

--- a/src/UI/TransactionsToastList/TransactionsToastList.tsx
+++ b/src/UI/TransactionsToastList/TransactionsToastList.tsx
@@ -19,7 +19,8 @@ import { TransactionToastType } from 'types/toasts.types';
 
 import {
   deleteCustomToast,
-  getRegisteredCustomIconComponents
+  getRegisteredCustomIconComponents,
+  getRegisteredToastCloseHandler
 } from 'utils/toasts/customToastsActions';
 import { getIsTransactionPending } from 'utils/transactions/transactionStateByStatus';
 
@@ -134,13 +135,17 @@ export const TransactionsToastList = ({
   const customToastsList = customToasts.map((props) => {
     const CustomComponent =
       getRegisteredCustomIconComponents(props.toastId) ?? null;
+    const onCloseHandler = getRegisteredToastCloseHandler(props.toastId);
 
     return (
       <CustomToast
         key={props.toastId}
         {...props}
         component={CustomComponent as never}
-        onDelete={() => handleDeleteCustomToast(props.toastId)}
+        onDelete={() => {
+          handleDeleteCustomToast(props.toastId);
+          onCloseHandler?.();
+        }}
         className={customToastClassName}
       />
     );

--- a/src/types/toasts.types.ts
+++ b/src/types/toasts.types.ts
@@ -8,6 +8,7 @@ interface SharedCustomToast {
    */
   duration?: number;
   type?: string;
+  onClose?: () => void;
 }
 export interface MessageCustomToastType extends SharedCustomToast {
   message: string;

--- a/src/utils/toasts/customToastsActions.ts
+++ b/src/utils/toasts/customToastsActions.ts
@@ -7,22 +7,34 @@ import { CustomToastType } from '../../types/toasts.types';
  * So a local dictionary is created here for registerd components
  */
 const componentsDictionary: Record<string, () => JSX.Element> = {};
+/**
+ * Callbacks cannot be sent trough Custom Events nor trough Redux
+ * So a local dictionary is created here for registered callbacks
+ */
+const componentsCloseHandlersDictionary: Record<string, () => void> = {};
 
 export const getRegisteredCustomIconComponents = (id: string) =>
   componentsDictionary[id];
 
+export const getRegisteredToastCloseHandler = (id: string) =>
+  componentsCloseHandlersDictionary[id];
+
 export const addNewCustomToast = (props: CustomToastType) => {
   if (props.component != null) {
-    const { component, ...rest } = props;
+    const { component, onClose, ...rest } = props;
     const { payload } = store.dispatch(
       addCustomToast({
         ...rest,
         // do not send component to Redux
-        component: null
+        component: null,
+        onClose: undefined
       })
     );
 
     componentsDictionary[payload.toastId] = component;
+    if (onClose) {
+      componentsCloseHandlersDictionary[payload.toastId] = onClose;
+    }
 
     return payload;
   }


### PR DESCRIPTION
### Issue
Can not sign other transactions after a cancel transaction action.
### Reproduce
Issue exists on version `2.18.0` of sdk-dapp.

### Root cause
Clear sign info on toast unmount which is triggered many times.
### Fix
Add support for onClose handler for custom toasts.
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
