### PR TITLE
Fixed issue in which signing a message, it would not clear URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - [Added ledger transport mock](https://github.com/multiversx/mx-sdk-dapp/pull/871)
+- [Fixed clear navigation url after signing a message](https://github.com/multiversx/mx-sdk-dapp/pull/872)
 
 ## [[v2.18.4]](https://github.com/multiversx/mx-sdk-dapp/pull/870)] - 2023-07-18
 

--- a/src/hooks/signMessage/useSignMessage.ts
+++ b/src/hooks/signMessage/useSignMessage.ts
@@ -258,7 +258,7 @@ export const useSignMessage = () => {
         ].includes(status as SignedMessageStatusesEnum)
       ) {
         // Failed to sign message
-        return onCancel({
+        onCancel({
           errorMessage:
             status === SignedMessageStatusesEnum.cancelled
               ? CANCELLED
@@ -268,7 +268,7 @@ export const useSignMessage = () => {
 
       if (signature && status === SignedMessageStatusesEnum.signed) {
         // Message was signed successfully
-        return dispatch(
+        dispatch(
           setSignSession({
             sessionId: currentSessionId,
             signedSession: {

--- a/src/types/signedMessage.types.ts
+++ b/src/types/signedMessage.types.ts
@@ -1,5 +1,6 @@
 export enum SignedMessageQueryParamsEnum {
   signature = 'signature',
   sessionId = 'sessionId',
-  status = 'status'
+  status = 'status',
+  address = 'address'
 }


### PR DESCRIPTION
### Issue/Feature

### Reproduce
Issue exists on version `2.18.4` of sdk-dapp.

### Root cause
Signing a message, it would not clear the URL params in the web-app.

### Fix
Execute clearNavigationHistory after parsing message from url.

### Additional changes
Added address as well in SignedMessageQueryParamsEnum in order to remove address from url when status is canceled/failed.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
