### PR TITLE
Fix next js unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Fixed NextJS provider double mounting](https://github.com/multiversx/mx-sdk-dapp/pull/874)
+- [Fixed NextJS provider double mounting](https://github.com/multiversx/mx-sdk-dapp/pull/876)
 
 ## [[v2.18.5]](https://github.com/multiversx/mx-sdk-dapp/pull/875)] - 2023-07-24
 - [Fixed `optionalRedirect` `setTimout` usage and window redirect](https://github.com/multiversx/mx-sdk-dapp/pull/873)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed NextJS provider double mounting](https://github.com/multiversx/mx-sdk-dapp/pull/874)
 
 ## [[v2.18.5]](https://github.com/multiversx/mx-sdk-dapp/pull/875)] - 2023-07-24
 - [Fixed `optionalRedirect` `setTimout` usage and window redirect](https://github.com/multiversx/mx-sdk-dapp/pull/873)

--- a/src/types/dappConfig.types.ts
+++ b/src/types/dappConfig.types.ts
@@ -2,4 +2,5 @@ export type DappConfigType = {
   logoutRoute?: string;
   shouldUseWebViewProvider?: boolean;
   cancelTransactionToastDuration?: number;
+  isSSR?: boolean;
 };

--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -107,7 +107,7 @@ export function AppInitializer({
   environment,
   dappConfig
 }: AppInitializerPropsType) {
-  const [isBrowser, setIsBrowser] = useState(false);
+  const [isBrowser, setIsBrowser] = useState(!dappConfig?.isSSR);
 
   const { initialized } = useAppInitializer({
     customNetworkConfig,


### PR DESCRIPTION
### Issue
NextJS double mounting because of [hydration](https://github.com/vercel/next.js/issues/36765)

### Reproduce
Issue exists on version `2.18.5` of sdk-dapp.

### Root cause
Server environment differs from browser environment in AppInitializer rendering of children
### Fix
Provide a custom flag when using the app with NextJS in dappConfig
### Additional changes

### Contains breaking changes
[] No

[x] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
