### PR TITLE
Fix signMessage missing callbackRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix the malformed url due to the missing callbackRoute](https://github.com/multiversx/mx-sdk-dapp/pull/884)
 - [Updated the @multiversx packages to their latest versions](https://github.com/multiversx/mx-sdk-dapp/pull/883)
 
 ## [[v2.19.2]](https://github.com/multiversx/mx-sdk-dapp/pull/881)] - 2023-07-28

--- a/src/utils/account/signMessage.ts
+++ b/src/utils/account/signMessage.ts
@@ -17,8 +17,8 @@ export const signMessage = async ({
 
   const { origin } = getWindowLocation();
   const callbackUrl = window?.location
-    ? `${origin}${callbackRoute}`
-    : `${callbackRoute}`;
+    ? `${origin}${callbackRoute ?? ''}`
+    : `${callbackRoute ?? ''}`;
   const signableMessage = new SignableMessage({
     address: new Address(address),
     message: Buffer.from(message, 'ascii')


### PR DESCRIPTION
### Issue/Feature
Avoid having `undefined` in the `callbackUrl` due to the missing `callbackRoute`

### Reproduce
Issue exists on version `2.` of sdk-dapp.

### Contains breaking changes
[x] No
[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
