### PR TITLE
[+] Added `addOriginToLocationPath` helper to parse redirect URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Added `addOriginToLocationPath` helper to parse redirect URLs](https://github.com/multiversx/mx-sdk-dapp/pull/888)
 - [Prevent signing transactions with sender different from current account](https://github.com/multiversx/mx-sdk-dapp/pull/887)
 - [Ledger login improvements and added support for bluetooth connect](https://github.com/multiversx/mx-sdk-dapp/pull/882)
 - [Fix WalletConnect Provider default logoutRoute](https://github.com/multiversx/mx-sdk-dapp/pull/886)

--- a/src/components/ProviderInitializer/hooks/useSetLedgerProvider.ts
+++ b/src/components/ProviderInitializer/hooks/useSetLedgerProvider.ts
@@ -72,12 +72,7 @@ export const useSetLedgerProvider = () => {
         console.warn('Could not initialise ledger app');
 
         if (shouldLogout) {
-          // Enforce absolute URL path to refresh the page on logout
-          const callbackUrl = logoutRoute?.startsWith('/')
-            ? logoutRoute
-            : `${window?.location?.origin ?? ''}${logoutRoute ?? ''}`;
-
-          logout(callbackUrl);
+          logout(logoutRoute);
         }
 
         return;

--- a/src/hooks/login/useExtensionLogin.ts
+++ b/src/hooks/login/useExtensionLogin.ts
@@ -13,7 +13,7 @@ import {
 import { LoginMethodsEnum } from 'types/enums.types';
 import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { optionalRedirect } from 'utils/internal';
-import { getWindowLocation } from 'utils/window/getWindowLocation';
+import { addOriginToLocationPath, getWindowLocation } from 'utils/window';
 import { useLoginService } from './useLoginService';
 
 export type UseExtensionLoginReturnType = [
@@ -54,9 +54,9 @@ export const useExtensionLogin = ({
         return;
       }
 
-      const { origin, pathname } = getWindowLocation();
+      const { pathname } = getWindowLocation();
       const callbackUrl: string = encodeURIComponent(
-        `${origin}${callbackRoute ?? pathname}`
+        addOriginToLocationPath(callbackRoute ?? pathname)
       );
 
       if (hasNativeAuth && !token) {

--- a/src/utils/account/signMessage.ts
+++ b/src/utils/account/signMessage.ts
@@ -1,7 +1,7 @@
 import { SignableMessage, Address } from '@multiversx/sdk-core';
 import { getAccountProvider } from 'providers';
 import { getAddress } from 'utils/account/getAddress';
-import { getWindowLocation } from 'utils/window/getWindowLocation';
+import { addOriginToLocationPath } from 'utils/window';
 
 export interface SignMessageType {
   message: string;
@@ -15,17 +15,13 @@ export const signMessage = async ({
   const address = await getAddress();
   const provider = getAccountProvider();
 
-  const { origin } = getWindowLocation();
-  const callbackUrl = window?.location
-    ? `${origin}${callbackRoute ?? ''}`
-    : `${callbackRoute ?? ''}`;
+  const callbackUrl = addOriginToLocationPath(callbackRoute);
   const signableMessage = new SignableMessage({
     address: new Address(address),
     message: Buffer.from(message, 'ascii')
   });
-  const signedMessage = await provider.signMessage(signableMessage, {
+
+  return await provider.signMessage(signableMessage, {
     callbackUrl: encodeURIComponent(callbackUrl)
   });
-
-  return signedMessage;
 };

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -7,7 +7,7 @@ import { getAddress } from './account';
 import { preventRedirects, safeRedirect } from './redirect';
 import { storage } from './storage';
 import { localStorageKeys } from './storage/local';
-import { getWindowLocation } from './window/getWindowLocation';
+import { addOriginToLocationPath } from './window';
 
 const broadcastLogoutAcrossTabs = (address: string) => {
   const storedData = storage.local.getItem(localStorageKeys.logoutEvent);
@@ -59,8 +59,7 @@ export async function logout(
   store.dispatch(logoutAction());
 
   try {
-    const needsCallbackUrl = isWalletProvider && !callbackUrl;
-    const url = needsCallbackUrl ? getWindowLocation().origin : callbackUrl;
+    const url = addOriginToLocationPath(callbackUrl);
 
     if (providerType === LoginMethodsEnum.none) {
       // logout does not exist in empty provider

--- a/src/utils/window/addOriginToLocationPath.ts
+++ b/src/utils/window/addOriginToLocationPath.ts
@@ -1,0 +1,16 @@
+import { getWindowLocation } from './getWindowLocation';
+
+export const addOriginToLocationPath = (path = '') => {
+  const location = getWindowLocation();
+
+  const isHrefUrl = path.startsWith('http') || path.startsWith('www.');
+
+  const shouldNotChangePath =
+    !location.origin || path.includes(location.origin) || isHrefUrl;
+
+  if (shouldNotChangePath) {
+    return path;
+  }
+
+  return `${location.origin}/${path.replace('/', '')}`;
+};

--- a/src/utils/window/index.ts
+++ b/src/utils/window/index.ts
@@ -1,1 +1,2 @@
+export * from './addOriginToLocationPath';
 export * from './getWindowLocation';

--- a/src/utils/window/tests/addOriginToLocationPath.test.ts
+++ b/src/utils/window/tests/addOriginToLocationPath.test.ts
@@ -1,0 +1,56 @@
+import { addOriginToLocationPath } from '../addOriginToLocationPath';
+
+let windowSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  windowSpy = jest.spyOn(window, 'window', 'get');
+});
+afterEach(() => {
+  windowSpy.mockRestore();
+});
+
+describe('Add window origin to pathname', () => {
+  it('should leave the path unchanged if origin is not available', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        origin: ''
+      }
+    }));
+
+    const path = addOriginToLocationPath('http://somesite/unlock');
+    expect(path).toStrictEqual('http://somesite/unlock');
+  });
+
+  it('should leave the path unchanged if it contains origin', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        origin: 'https://multiversx.com'
+      }
+    }));
+
+    const path = addOriginToLocationPath('http://somesite/unlock');
+    expect(path).toStrictEqual('http://somesite/unlock');
+  });
+
+  it('should leave the path unchanged if it contains the same origin as current one', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        origin: 'http://somesite'
+      }
+    }));
+
+    const path = addOriginToLocationPath('http://somesite/unlock');
+    expect(path).toStrictEqual('http://somesite/unlock');
+  });
+
+  it('should add the current origin to the path', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        origin: 'https://multiversx.com'
+      }
+    }));
+
+    const path = addOriginToLocationPath('/unlock');
+    expect(path).toStrictEqual('https://multiversx.com/unlock');
+  });
+});


### PR DESCRIPTION
### Feature
Improvements to redirect URLs parsing. Added `addOriginToLocationPath` helper to parse redirect URLs. The helper checks if the URL is empty and if it has origin.
- if the URL is empty string, add the current origin;
- if the URL is a full href, leave it unchanged;
- if the URL contains current origin, leave it unchanged;
- if the URL is just a path, add current origin.

### Purpose
The idea is to force a page reload on logout and prevent page reloads on login (unless necessary).

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[x] Unit tests
