### PR TITLE
Memoize dapp config in order to not reinitialize app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- [Memoize dappConfig in order to not trigger initializeApp on every DappProvider rerender](https://github.com/multiversx/mx-sdk-dapp/pull/894)
 ## [[v2.19.3]](https://github.com/multiversx/mx-sdk-dapp/pull/890)] - 2023-08-21
 - [Added `DataTestIdsEnum` to `data-testid` HTML tags](https://github.com/multiversx/mx-sdk-dapp/pull/889)
 - [Added `addOriginToLocationPath` helper to parse redirect URLs](https://github.com/multiversx/mx-sdk-dapp/pull/888)


### PR DESCRIPTION
### Issue/Feature
On every render in _app (from NextJS pages directory) and in any React app that it is rerendering DappProvider, the dappConfig property creates a new reference which will trigger the intializeApp()

### Reproduce
Issue exists on version `2.19.3` of sdk-dapp.

### Root cause
Rerender of DappProvider creates new reference of dappConfig.

### Fix
Memoize the dappConfig and use it in order to not trigger a new app initialization.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
