### PR TITLE
[+] Removed `loginMethod` from the `isLoggedIn` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+- [Removed `loginMethod` from the `isLoggedIn` check](https://github.com/multiversx/mx-sdk-dapp/pull/903)
+
 ## [[v2.19.7]](https://github.com/multiversx/mx-sdk-dapp/pull/901)] - 2023-09-01
 - [Added ledger usernames validation](https://github.com/multiversx/mx-sdk-dapp/pull/900)
 

--- a/src/reduxStore/middlewares/loginSessionMiddleware.ts
+++ b/src/reduxStore/middlewares/loginSessionMiddleware.ts
@@ -1,7 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import throttle from 'lodash.throttle';
 import { LOGOUT_ACTION_NAME } from 'constants/index';
-import { deriveIsLoggedIn } from 'reduxStore/selectors/helpers';
 import { invalidateLoginSession } from 'reduxStore/slices';
 import { RootState } from 'reduxStore/store';
 import { getNewLoginExpiresTimestamp, setLoginExpiresAt } from 'storage/local';
@@ -22,17 +21,18 @@ export const loginSessionMiddleware: any =
     if (whitelistedActions.includes(action.type)) {
       return next(action);
     }
+
     const appState: RootState = store.getState();
     const loginTimestamp = storage.local.getItem(
       localStorageKeys.loginExpiresAt
     );
-    const isLoggedIn = deriveIsLoggedIn(
-      appState?.loginInfo?.loginMethod,
-      appState?.account.address
-    );
+
+    const isLoggedIn = Boolean(appState?.account.address);
+
     if (!isLoggedIn) {
       return next(action);
     }
+
     if (loginTimestamp == null) {
       return setLoginExpiresAt(getNewLoginExpiresTimestamp());
     }
@@ -53,5 +53,6 @@ export const loginSessionMiddleware: any =
 
       throttledSetNewExpires();
     }
+
     return next(action);
   };

--- a/src/reduxStore/selectors/helpers.ts
+++ b/src/reduxStore/selectors/helpers.ts
@@ -1,13 +1,7 @@
 import isEqual from 'lodash.isequal';
 import { createSelectorCreator, defaultMemoize } from 'reselect';
-import { LoginMethodsEnum } from 'types';
 
 export const createDeepEqualSelector = createSelectorCreator(
   defaultMemoize,
   isEqual
 );
-
-export const deriveIsLoggedIn = (
-  loginMethod: LoginMethodsEnum,
-  address?: string
-) => loginMethod != LoginMethodsEnum.none && Boolean(address);

--- a/src/reduxStore/selectors/loginInfoSelectors.ts
+++ b/src/reduxStore/selectors/loginInfoSelectors.ts
@@ -1,6 +1,6 @@
 import { RootState } from 'reduxStore/store';
 import { addressSelector } from './accountInfoSelectors';
-import { createDeepEqualSelector, deriveIsLoggedIn } from './helpers';
+import { createDeepEqualSelector } from './helpers';
 
 export const loginInfoSelector = (state: RootState) => state.loginInfo;
 
@@ -12,7 +12,7 @@ export const loginMethodSelector = createDeepEqualSelector(
 export const isLoggedInSelector = createDeepEqualSelector(
   loginInfoSelector,
   addressSelector,
-  (state, address) => deriveIsLoggedIn(state.loginMethod, address)
+  (_, address) => Boolean(address)
 );
 
 export const walletConnectLoginSelector = createDeepEqualSelector(

--- a/src/wrappers/AxiosInterceptorContext/components/AxiosInterceptorContextProvider.tsx
+++ b/src/wrappers/AxiosInterceptorContext/components/AxiosInterceptorContextProvider.tsx
@@ -7,7 +7,6 @@ import React, {
   createContext
 } from 'react';
 import { loginInfoSelector } from 'reduxStore/selectors';
-import { deriveIsLoggedIn } from 'reduxStore/selectors/helpers';
 import { RootState, store } from 'reduxStore/store';
 import { LoginInfoStateType } from '../../../reduxStore/slices/loginInfoSlice';
 
@@ -54,7 +53,7 @@ export function AxiosInterceptorContextProvider({
   const value: AxiosInterceptorContextPropsType = {
     address,
     setAddress,
-    isLoggedIn: deriveIsLoggedIn(loginInfo.loginMethod, address),
+    isLoggedIn: Boolean(address),
     loginInfo,
     setLoginInfo: (data: LoginInfoStateType) => setLoginInfo(data)
   };


### PR DESCRIPTION
### Issue
`isLoggedIn` returns `true`, but `address` is `''`

### Reproduce
Issue exists on version `2.19.7` of sdk-dapp.

### Root cause
When dispatching `logoutAction`, the `loginMethod` is cleared after the `address`, so the `isLoggedIn` selector will return `true` for a brief period, because the `loginMethod` field will not be cleared, but the `address` will.

### Fix
`isLoggedIn` will depend only on the `address`. A user is logged in if the address is present and vice versa.

### Contains breaking changes
[] No

[x] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[] User testing
[x] Unit tests
