### PR TITLE
[FIX] Changed `safeRedirect` method to force page reload on logout to ensure fresh states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Changed `safeRedirect` method to force page reload on logout to ensure fresh states](https://github.com/multiversx/mx-sdk-dapp/pull/906)
 
 ## [[v2.19.8]](https://github.com/multiversx/mx-sdk-dapp/pull/904)] - 2023-09-04
 - [Removed `loginMethod` from the `isLoggedIn` check](https://github.com/multiversx/mx-sdk-dapp/pull/903)

--- a/src/components/BatchTransactionsSender/BatchTransactionsSender.ts
+++ b/src/components/BatchTransactionsSender/BatchTransactionsSender.ts
@@ -29,8 +29,9 @@ import { removeTransactionParamsFromUrl } from 'utils/transactions/removeTransac
  */
 const optionalRedirect = (sessionInformation: SignedTransactionsBodyType) => {
   const redirectRoute = sessionInformation.redirectRoute;
+
   if (redirectRoute) {
-    safeRedirect(redirectRoute);
+    safeRedirect({ url: redirectRoute });
   }
 };
 

--- a/src/components/TransactionSender/TransactionSender.ts
+++ b/src/components/TransactionSender/TransactionSender.ts
@@ -40,7 +40,7 @@ const optionalRedirect = (sessionInformation: SignedTransactionsBodyType) => {
   const redirectRoute = sessionInformation.redirectRoute;
 
   if (redirectRoute) {
-    safeRedirect(redirectRoute);
+    safeRedirect({ url: redirectRoute });
   }
 };
 

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -134,7 +134,7 @@ export function useSignTransactionsWithDevice(
         customTransactionInformation?.redirectAfterSign &&
         !locationIncludesCallbackRoute
       ) {
-        safeRedirect(callbackRoute);
+        safeRedirect({ url: callbackRoute });
       }
     }
   }

--- a/src/utils/internal/optionalRedirect.ts
+++ b/src/utils/internal/optionalRedirect.ts
@@ -14,7 +14,6 @@ export function optionalRedirect({
   options
 }: OptionalRedirectType) {
   const shouldRedirect = Boolean(callbackRoute);
-
   const hasOnLoginRedirect = typeof onLoginRedirect === 'function';
 
   if (shouldRedirect && callbackRoute != null) {
@@ -26,7 +25,10 @@ export function optionalRedirect({
     const { pathname } = getWindowLocation();
 
     if (!pathname.includes(callbackRoute)) {
-      safeRedirect(callbackRoute, DEFAULT_TIMEOUT);
+      safeRedirect({
+        url: callbackRoute,
+        timeout: DEFAULT_TIMEOUT
+      });
     }
   }
 }

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -89,7 +89,7 @@ function redirectToCallbackUrl(
     if (typeof onRedirect === 'function') {
       onRedirect(callbackUrl);
     } else {
-      safeRedirect(callbackUrl);
+      safeRedirect({ url: callbackUrl, shouldForcePageReload: true });
     }
   }
 }

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -4,18 +4,25 @@ export const preventRedirects = (shouldPreventRedirect = true) => {
   preventRedirect = shouldPreventRedirect;
 };
 
-export const safeRedirect = (url: string, timeout = 0) => {
+export const safeRedirect = ({
+  shouldForcePageReload,
+  timeout = 0,
+  url
+}: {
+  shouldForcePageReload?: boolean;
+  timeout?: number;
+  url: string;
+}) => {
   if (!preventRedirect) {
     setTimeout(() => {
       if (!window) {
         return;
       }
 
-      // Navigate to callbackUrl without page refresh
-      // if we are in the same origin
+      // Navigate to callbackUrl without page refresh if we are in the same origin
       const isSameOriginRedirect = url?.startsWith('/');
 
-      if (isSameOriginRedirect) {
+      if (isSameOriginRedirect && !shouldForcePageReload) {
         return window.history.pushState('', '', url);
       }
 

--- a/src/wrappers/AuthenticatedRoutesWrapper/AuthenticatedRoutesWrapper.tsx
+++ b/src/wrappers/AuthenticatedRoutesWrapper/AuthenticatedRoutesWrapper.tsx
@@ -27,9 +27,7 @@ export const AuthenticatedRoutesWrapper = ({
 }) => {
   const searchParamAddress = getSearchParamAddress();
   const isLoggedIn = useSelector(isLoggedInSelector);
-
   const isAccountLoading = useSelector(isAccountLoadingSelector);
-
   const walletLogin = useSelector(walletLoginSelector);
 
   const getLocationPathname = () => {
@@ -56,7 +54,7 @@ export const AuthenticatedRoutesWrapper = ({
       return onRedirect(unlockRoute);
     }
 
-    safeRedirect(unlockRoute);
+    safeRedirect({ url: unlockRoute });
   }, [shouldRedirect, unlockRoute]);
 
   const isValidWalletLoginAttempt = walletLogin != null && searchParamAddress;


### PR DESCRIPTION
### Issue
Wrong states occur after logout with a `history.pushState` redirect

### Reproduce
Issue exists on version `2.19.8` of sdk-dapp.

### Root cause
React router DOM handles the routing differently than `window.history` does and incorrect states occur. Also, incorrect or partial data may occur at logout without force page reload.

### Fix
Ensure redirect with page reload no matter what on logout.

### Additional changes

### Contains breaking changes
[x] No
[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[x] Unit tests
