### PR TITLE
clear extension bgr when cancel tx from dapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- [Add back cancelAction when cancelling a transaction and remove it from transaction toast discard](https://github.com/multiversx/mx-sdk-dapp/pull/919)
 ## [[v2.20.2]](https://github.com/multiversx/mx-sdk-dapp/pull/913)] - 2023-09-13
 - [Changed Ledger authentication texts for v.23 of MultiversX app](https://github.com/multiversx/mx-sdk-dapp/pull/910)
 - [Fix transaction cancellation when a transaction toast is discarded](https://github.com/multiversx/mx-wallet-dapp/pull/915)

--- a/src/UI/SignTransactionsModals/components/ConfirmationScreen.tsx
+++ b/src/UI/SignTransactionsModals/components/ConfirmationScreen.tsx
@@ -52,8 +52,7 @@ export const ConfirmationScreen = ({
 
   const transactionStatusToastProps: TransactionStatusToastType = {
     signError,
-    canceledTransactionsMessage,
-    onDelete: handleClose
+    canceledTransactionsMessage
   };
 
   const shouldShowTransactionStatusToast =

--- a/src/UI/SignTransactionsModals/components/TransactionStatusToast.tsx
+++ b/src/UI/SignTransactionsModals/components/TransactionStatusToast.tsx
@@ -16,7 +16,7 @@ import { WithClassnameType } from '../../types';
 export interface TransactionStatusToastType extends WithClassnameType {
   signError: string | null;
   canceledTransactionsMessage: string | null;
-  onDelete: () => void;
+  onDelete?: () => void;
 }
 
 export const TransactionStatusToast = ({
@@ -52,7 +52,7 @@ export const TransactionStatusToast = ({
         dappConfig.cancelTransactionToastDuration ??
         CANCEL_TRANSACTION_TOAST_DEFAULT_DURATION,
       component: () => <StatusMessageComponent type={type} message={message} />,
-      onClose: () => onDelete(),
+      onClose: () => onDelete?.(),
       icon: faWarning
     });
   }, []);

--- a/src/hooks/transactions/useSignTransactionsCommonData.tsx
+++ b/src/hooks/transactions/useSignTransactionsCommonData.tsx
@@ -12,6 +12,7 @@ import {
   transactionsToSignSelector
 } from 'reduxStore/selectors';
 import {
+  clearAllTransactionsToSign,
   clearTransactionsInfoForSessionId,
   setSignTransactionsCancelMessage
 } from 'reduxStore/slices';
@@ -65,6 +66,7 @@ export const useSignTransactionsCommonData = () => {
   function clearSignInfo(sessionId?: string) {
     const isExtensionProvider = provider instanceof ExtensionProvider;
 
+    dispatch(clearAllTransactionsToSign());
     dispatch(clearTransactionsInfoForSessionId(sessionId));
 
     if (!isExtensionProvider) {
@@ -72,6 +74,7 @@ export const useSignTransactionsCommonData = () => {
     }
 
     clearTransactionStatusMessage();
+    ExtensionProvider.getInstance()?.cancelAction?.();
   }
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6816,9 +6816,9 @@ defaults@^1.0.3:
     clone "^1.0.2"
 
 define-data-property@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.0.1.tgz#37589faaa735405b557fcb9537b46b575655c4cb"
-  integrity sha512-22M+6zEspQHx10bfFQl2ET39IvfuQ7+rZIH7+ard8fCC4hPmkOSy+8JhKxBRLaWUziJ0O63NTYT97LR8zUfPTw==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.0.tgz#0db13540704e1d8d479a0656cf781267531b9451"
+  integrity sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==
   dependencies:
     get-intrinsic "^1.2.1"
     gopd "^1.0.1"
@@ -6829,7 +6829,7 @@ define-lazy-prop@^2.0.0:
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
-define-properties@^1.1.2, define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
+define-properties@^1.1.2, define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0, define-properties@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
   integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
@@ -12680,13 +12680,15 @@ promise.allsettled@^1.0.0:
     iterate-value "^1.0.2"
 
 promise.prototype.finally@^3.1.0:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.5.tgz#94ba0a29f925e6da0709faddf85163cd8ed892c2"
-  integrity sha512-4TQ3Dk8yyUZGyU+UXInKdkQ2b6xtiBXAIScGAtGnXVmJtG1uOrxRgbF1ggIu72uzoWFzUfT3nUKa1SuMm9NBdg==
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.7.tgz#9d163f58edf3004d14878c988a22b1cb45e03407"
+  integrity sha512-iL9OcJRUZcCE5xn6IwhZxO+eMM0VEXjkETHy+Nk+d9q3s7kxVtPg+mBlMO+ZGxNKNMODyKmy/bOyt/yhxTnvEw==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.2.0"
+    define-properties "^1.2.1"
     es-abstract "^1.22.1"
+    get-intrinsic "^1.2.1"
+    set-function-name "^2.0.1"
 
 prompts@^2.0.1, prompts@^2.4.0, prompts@^2.4.1:
   version "2.4.2"
@@ -13746,12 +13748,13 @@ set-cookie-parser@^2.4.6:
   resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz#131921e50f62ff1a66a461d7d62d7b21d5d15a51"
   integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
 
-set-function-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.0.tgz#e59e53e7fa23f9c2da1c0999fa202d5ed09c4756"
-  integrity sha512-WmS8UHojv5s1eSoRSmzO5zzgDq8PE1/X/ij0k+9fMYmINCc6+j+SF3Om8YyucKn2yjnK4ItNZOoQycNnHsZJTw==
+set-function-name@^2.0.0, set-function-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.1.tgz#12ce38b7954310b9f61faa12701620a0c882793a"
+  integrity sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==
   dependencies:
     define-data-property "^1.0.1"
+    functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.0"
 
 set-value@^2.0.0, set-value@^2.0.1:


### PR DESCRIPTION
### Issue

### Reproduce
Issue exists on version `2.20.2` of sdk-dapp.
DeFi wallet would not clear the transaction when cancelled from DApps

### Root cause
cancelAction was removed when canceling transactions from DApps
### Fix
Add back cancelAction when cancelling a transaction and remove it from transaction toast discard

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests