### PR TITLE
Add support to allow multiple web wallet providers implementations on the same dApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Add support to allow multiple web wallet providers implementations on the same dApp](https://github.com/multiversx/mx-sdk-dapp/pull/934)
+
 ## [[v2.21.0]](https://github.com/multiversx/mx-sdk-dapp/pull/933)] - 2023-09-21
 
 - [Prevent duplicate custom toasts with the same ID](https://github.com/multiversx/mx-sdk-dapp/pull/932)

--- a/src/UI/webWallet/WebWalletLoginButton/WebWalletLoginButton.tsx
+++ b/src/UI/webWallet/WebWalletLoginButton/WebWalletLoginButton.tsx
@@ -12,6 +12,12 @@ export interface WebWalletLoginButtonPropsType
   children?: ReactNode;
   loginButtonText?: string;
   disabled?: boolean;
+  /**
+   * This property is used to override the default wallet address.
+   * This is useful when you want to use a custom wallet provider.
+   * It overrides the wallet address from the network, including the wallet address from the custom network config from the DappProvider.
+   * */
+  customWalletAddress?: string;
 }
 
 export const WebWalletLoginButton: (
@@ -25,12 +31,14 @@ export const WebWalletLoginButton: (
   nativeAuth,
   'data-testid': dataTestId,
   loginButtonText = 'MultiversX Web Wallet',
-  disabled
+  disabled,
+  customWalletAddress
 }) => {
   const [onInitiateLogin] = useWebWalletLogin({
     callbackRoute,
     nativeAuth,
-    token
+    token,
+    customWalletAddress
   });
   const disabledConnectButton = getIsNativeAuthSingingForbidden(token);
 

--- a/src/hooks/login/useWebWalletLogin.ts
+++ b/src/hooks/login/useWebWalletLogin.ts
@@ -17,6 +17,12 @@ import { useLoginService } from './useLoginService';
 export interface UseWebWalletLoginPropsType
   extends Omit<OnProviderLoginType, 'onLoginRedirect'> {
   redirectDelayMilliseconds?: number;
+  /**
+   * This property is used to override the default wallet address.
+   * This is useful when you want to use a custom wallet provider.
+   * It overrides the wallet address from the network, including the wallet address from the custom network config from the DappProvider.
+   * */
+  customWalletAddress?: string;
 }
 
 export type UseWebWalletLoginReturnType = [
@@ -28,7 +34,8 @@ export const useWebWalletLogin = ({
   callbackRoute,
   token: tokenToSign,
   nativeAuth,
-  redirectDelayMilliseconds = 100
+  redirectDelayMilliseconds = 100,
+  customWalletAddress
 }: UseWebWalletLoginPropsType): UseWebWalletLoginReturnType => {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -45,7 +52,9 @@ export const useWebWalletLogin = ({
     }
     try {
       setIsLoading(true);
-      const provider = newWalletProvider(network.walletAddress);
+      const provider = newWalletProvider(
+        customWalletAddress ?? network.walletAddress
+      );
 
       const now = new Date();
       const expires: number = now.setMinutes(now.getMinutes() + 3) / 1000;


### PR DESCRIPTION
### Feature
Add support to allow multiple web wallet providers implementations on the same dApp

### Additional changes
Decorate the initial web wallet login button and useWebWalletLogin hook with the `customWalletAddress` prop

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests

How to use it?


```
<WebWalletLoginButton
   loginButtonText='Web Wallet'
   data-testid='webWalletLoginBtn'
   callbackRoute='/dahsboard',
   nativeAuth={true}
/>
<WebWalletLoginButton
   loginButtonText='Custom Web Wallet'
   data-testid='customWebWalletLoginBtn'
   callbackRoute='/dahsboard',
   nativeAuth={true}
   customWalletAddress: 'https://your-wallet.com'
/>
```
