### PR TITLE
Custom web wallet config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Added support for custom Web Wallet address](https://github.com/multiversx/mx-sdk-dapp/pull/940)
 ## [[v2.21.1]](https://github.com/multiversx/mx-sdk-dapp/pull/939)] - 2023-09-29
 - [Added `getDefaultCallbackUrl` helper](https://github.com/multiversx/mx-sdk-dapp/pull/936)
 - [Return native auth token when refreshing the token](https://github.com/multiversx/mx-sdk-dapp/pull/938)

--- a/README.md
+++ b/README.md
@@ -311,6 +311,15 @@ you can easily import and use them.
 >
 ```
 
+If you have a custom Web Wallet service you can integrate it by using the `customWalletAddress` prop:
+```jsx
+<WebWalletLoginButton
+  callbackRoute="/dashboard"
+  loginButtonText="Custom Web Wallet login"
+  customWalletAddress="https://custom-web-wallet.com"
+>
+```
+
 All login buttons and hooks accept a prop called `redirectAfterLogin` which specifies of the user should be redirected automatically after login.
 The default value for this boolean is false, since most apps listen for the "isLoggedIn" boolean and redirect programmatically.
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ you can easily import and use them.
 >
 ```
 
-If you have a custom Web Wallet service you can integrate it by using the `customWalletAddress` prop:
+If you have a custom Web Wallet provider you can integrate it by using the `customWalletAddress` prop:
 ```jsx
 <WebWalletLoginButton
   callbackRoute="/dashboard"

--- a/src/UI/webWallet/WebWalletLoginButton/WebWalletLoginButton.tsx
+++ b/src/UI/webWallet/WebWalletLoginButton/WebWalletLoginButton.tsx
@@ -1,13 +1,15 @@
 import React, { ReactNode } from 'react';
-import { useWebWalletLogin } from 'hooks/login/useWebWalletLogin';
+import {
+  UseWebWalletLoginPropsType,
+  useWebWalletLogin
+} from 'hooks/login/useWebWalletLogin';
 import { getIsNativeAuthSingingForbidden } from 'services/nativeAuth/helpers';
-import { OnProviderLoginType } from '../../../types';
 import { LoginButton } from '../../LoginButton/LoginButton';
 import { WithClassnameType } from '../../types';
 
 export interface WebWalletLoginButtonPropsType
-  extends WithClassnameType,
-    Omit<OnProviderLoginType, 'onLoginRedirect'> {
+  extends UseWebWalletLoginPropsType,
+    WithClassnameType {
   buttonClassName?: string;
   children?: ReactNode;
   loginButtonText?: string;
@@ -25,12 +27,14 @@ export const WebWalletLoginButton: (
   nativeAuth,
   'data-testid': dataTestId,
   loginButtonText = 'MultiversX Web Wallet',
-  disabled
+  disabled,
+  customWalletAddress
 }) => {
   const [onInitiateLogin] = useWebWalletLogin({
     callbackRoute,
     nativeAuth,
-    token
+    token,
+    customWalletAddress
   });
   const disabledConnectButton = getIsNativeAuthSingingForbidden(token);
 

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -20,7 +20,10 @@ import {
   isLoggedInSelector,
   tokenLoginSelector
 } from 'reduxStore/selectors/loginInfoSelectors';
-import { networkSelector } from 'reduxStore/selectors/networkConfigSelectors';
+import {
+  networkSelector,
+  walletAddressSelector
+} from 'reduxStore/selectors/networkConfigSelectors';
 import {
   setAccount,
   setIsAccountLoading,
@@ -47,6 +50,7 @@ let initalizingLedger = false;
 
 export function ProviderInitializer() {
   const network = useSelector(networkSelector);
+  const walletAddress = useSelector(walletAddressSelector);
   const walletConnectLogin = useSelector(walletConnectLoginSelector);
   const loginMethod = useSelector(loginMethodSelector);
   const walletLogin = useSelector(walletLoginSelector);
@@ -147,7 +151,7 @@ export function ProviderInitializer() {
   }
 
   async function tryAuthenticateWalletUser() {
-    const provider = newWalletProvider(network.walletAddress);
+    const provider = newWalletProvider(walletAddress);
     setAccountProvider(provider);
 
     if (walletLogin == null) {

--- a/src/hooks/login/useWebWalletLogin.ts
+++ b/src/hooks/login/useWebWalletLogin.ts
@@ -7,6 +7,7 @@ import { newWalletProvider } from 'utils';
 import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
 import {
+  AccountInfoSliceNetworkType,
   InitiateLoginFunctionType,
   LoginHookGenericStateType,
   OnProviderLoginType
@@ -17,7 +18,7 @@ import { useLoginService } from './useLoginService';
 export interface UseWebWalletLoginPropsType
   extends Omit<OnProviderLoginType, 'onLoginRedirect'> {
   redirectDelayMilliseconds?: number;
-  customWalletAddress?: string;
+  customWalletAddress?: AccountInfoSliceNetworkType['customWalletAddress'];
 }
 
 export type UseWebWalletLoginReturnType = [

--- a/src/hooks/login/useWebWalletLogin.ts
+++ b/src/hooks/login/useWebWalletLogin.ts
@@ -46,9 +46,7 @@ export const useWebWalletLogin = ({
       throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
     }
 
-    if (customWalletAddress) {
-      dispatch(setCustomWalletAddress(customWalletAddress));
-    }
+    dispatch(setCustomWalletAddress(customWalletAddress));
 
     try {
       setIsLoading(true);

--- a/src/hooks/login/useWebWalletLogin.ts
+++ b/src/hooks/login/useWebWalletLogin.ts
@@ -18,6 +18,18 @@ import { useLoginService } from './useLoginService';
 export interface UseWebWalletLoginPropsType
   extends Omit<OnProviderLoginType, 'onLoginRedirect'> {
   redirectDelayMilliseconds?: number;
+  /**
+   * @param {string} customWalletAddress if set, will be used as main `walletAddress`
+   * @description
+   * The `customWalletAddress` property is used to override the default `walletAddress`.
+   * This is useful when you want to use a custom wallet provider.
+   * It overrides the network's wallet address, including the wallet address from the custom network config specified in the `DappProvider`.
+   * @example
+   * <WebWalletLoginButton
+      {...otherLoginProps}
+      customWalletAddress="https://custom-web-wallet.com"
+     >
+   */
   customWalletAddress?: AccountInfoSliceNetworkType['customWalletAddress'];
 }
 

--- a/src/hooks/login/useWebWalletLogin.ts
+++ b/src/hooks/login/useWebWalletLogin.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { SECOND_LOGIN_ATTEMPT_ERROR } from 'constants/errorsMessages';
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
 import { networkSelector } from 'reduxStore/selectors';
-import { setWalletLogin } from 'reduxStore/slices';
+import { setCustomWalletAddress, setWalletLogin } from 'reduxStore/slices';
 import { newWalletProvider } from 'utils';
 import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
@@ -17,6 +17,7 @@ import { useLoginService } from './useLoginService';
 export interface UseWebWalletLoginPropsType
   extends Omit<OnProviderLoginType, 'onLoginRedirect'> {
   redirectDelayMilliseconds?: number;
+  customWalletAddress?: string;
 }
 
 export type UseWebWalletLoginReturnType = [
@@ -28,7 +29,8 @@ export const useWebWalletLogin = ({
   callbackRoute,
   token: tokenToSign,
   nativeAuth,
-  redirectDelayMilliseconds = 100
+  redirectDelayMilliseconds = 100,
+  customWalletAddress
 }: UseWebWalletLoginPropsType): UseWebWalletLoginReturnType => {
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -43,9 +45,16 @@ export const useWebWalletLogin = ({
     if (isLoggedIn) {
       throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
     }
+
+    if (customWalletAddress) {
+      dispatch(setCustomWalletAddress(customWalletAddress));
+    }
+
     try {
       setIsLoading(true);
-      const provider = newWalletProvider(network.walletAddress);
+      const provider = newWalletProvider(
+        customWalletAddress ?? network.walletAddress
+      );
 
       const now = new Date();
       const expires: number = now.setMinutes(now.getMinutes() + 3) / 1000;

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -22,8 +22,8 @@ import { getProviderType } from 'providers/utils';
 
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
 import {
-  networkSelector,
-  signTransactionsCancelMessageSelector
+  signTransactionsCancelMessageSelector,
+  walletAddressSelector
 } from 'reduxStore/selectors';
 import {
   clearAllTransactionsToSign,
@@ -53,7 +53,7 @@ export const useSignTransactions = () => {
   const dispatch = useDispatch();
   const savedCallback = useRef('/');
   const { provider } = useGetAccountProvider();
-  const network = useSelector(networkSelector);
+  const walletAddress = useSelector(walletAddressSelector);
 
   const providerType = getProviderType(provider);
   const isSigningRef = useRef(false);
@@ -206,7 +206,7 @@ export const useSignTransactions = () => {
           sessionId,
           callbackRoute,
           isGuarded: isGuarded && allowGuardian,
-          walletAddress: network.walletAddress
+          walletAddress
         });
 
       if (needs2FaSigning) {

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -7,7 +7,7 @@ import { useGetAccountProvider } from 'hooks/account/useGetAccountProvider';
 import { useSignMultipleTransactions } from 'hooks/transactions/useSignMultipleTransactions';
 
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
-import { egldLabelSelector, networkSelector } from 'reduxStore/selectors';
+import { egldLabelSelector, walletAddressSelector } from 'reduxStore/selectors';
 import {
   moveTransactionsToSignedState,
   setSignTransactionsError
@@ -57,7 +57,7 @@ export function useSignTransactionsWithDevice(
   const { onCancel, verifyReceiverScam = true, hasGuardianScreen } = props;
   const { transactionsToSign, hasTransactions } =
     useSignTransactionsCommonData();
-  const network = useSelector(networkSelector);
+  const walletAddress = useSelector(walletAddressSelector);
   const getLedgerProvider = useGetLedgerProvider();
 
   const egldLabel = useSelector(egldLabelSelector);
@@ -110,7 +110,7 @@ export function useSignTransactionsWithDevice(
         callbackRoute,
         hasGuardianScreen,
         isGuarded: isGuarded && allowGuardian,
-        walletAddress: network.walletAddress
+        walletAddress
       });
 
     if (needs2FaSigning) {

--- a/src/reduxStore/selectors/networkConfigSelectors.ts
+++ b/src/reduxStore/selectors/networkConfigSelectors.ts
@@ -48,6 +48,11 @@ export const explorerAddressSelector = createDeepEqualSelector(
   (state) => state.explorerAddress
 );
 
+export const walletAddressSelector = createDeepEqualSelector(
+  networkSelector,
+  (state) => state.customWalletAddress ?? state.walletAddress
+);
+
 export const egldLabelSelector = createDeepEqualSelector(
   networkSelector,
   (state) => state.egldLabel

--- a/src/reduxStore/slices/networkConfigSlice.ts
+++ b/src/reduxStore/slices/networkConfigSlice.ts
@@ -1,5 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import omit from 'lodash.omit';
+import { REHYDRATE } from 'redux-persist';
+import { logoutAction } from 'reduxStore/commonActions';
 import {
   AccountInfoSliceNetworkType,
   BaseNetworkType,
@@ -62,11 +64,31 @@ export const networkConfigSlice = createSlice({
       action: PayloadAction<string>
     ) => {
       state.chainID = action.payload;
+    },
+    setCustomWalletAddress: (
+      state: NetworkConfigStateType,
+      action: PayloadAction<string>
+    ) => {
+      state.network.customWalletAddress = action.payload;
     }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(logoutAction, (state: NetworkConfigStateType) => {
+      state.network.customWalletAddress = undefined;
+    }),
+      builder.addCase(REHYDRATE, (state, action: any) => {
+        if (!action.payload?.network?.customWalletAddress) {
+          return;
+        }
+        const {
+          network: { customWalletAddress }
+        } = action.payload;
+        state.network.customWalletAddress = customWalletAddress;
+      });
   }
 });
 
-export const { initializeNetworkConfig, setChainID } =
+export const { initializeNetworkConfig, setChainID, setCustomWalletAddress } =
   networkConfigSlice.actions;
 
 export default networkConfigSlice.reducer;

--- a/src/reduxStore/slices/networkConfigSlice.ts
+++ b/src/reduxStore/slices/networkConfigSlice.ts
@@ -67,7 +67,7 @@ export const networkConfigSlice = createSlice({
     },
     setCustomWalletAddress: (
       state: NetworkConfigStateType,
-      action: PayloadAction<string>
+      action: PayloadAction<AccountInfoSliceNetworkType['customWalletAddress']>
     ) => {
       state.network.customWalletAddress = action.payload;
     }

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -18,18 +18,6 @@ export interface BaseNetworkType {
 export interface AccountInfoSliceNetworkType extends BaseNetworkType {
   walletConnectBridgeAddress: string;
   walletConnectV2RelayAddress: string;
-  /**
-   * @param {string} customWalletAddress if set, will be used as main `walletAddress`
-   * @description
-   * The `customWalletAddress` property is used to override the default `walletAddress`.
-   * This is useful when you want to use a custom wallet provider.
-   * It overrides the network's wallet address, including the wallet address from the custom network config specified in the `DappProvider`.
-   * @example
-   * <WebWalletLoginButton
-      {...otherLoginProps}
-      customWalletAddress="https://custom-web-wallet.com"
-     >
-   */
   customWalletAddress?: string;
 }
 

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -18,6 +18,9 @@ export interface BaseNetworkType {
 export interface AccountInfoSliceNetworkType extends BaseNetworkType {
   walletConnectBridgeAddress: string;
   walletConnectV2RelayAddress: string;
+  /**
+   * if set, will be used as main `walletAddress`
+   */
   customWalletAddress?: string;
 }
 

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -19,7 +19,16 @@ export interface AccountInfoSliceNetworkType extends BaseNetworkType {
   walletConnectBridgeAddress: string;
   walletConnectV2RelayAddress: string;
   /**
-   * if set, will be used as main `walletAddress`
+   * @param {string} customWalletAddress if set, will be used as main `walletAddress`
+   * @description
+   * The `customWalletAddress` property is used to override the default `walletAddress`.
+   * This is useful when you want to use a custom wallet provider.
+   * It overrides the network's wallet address, including the wallet address from the custom network config specified in the `DappProvider`.
+   * @example
+   * <WebWalletLoginButton
+      {...otherLoginProps}
+      customWalletAddress="https://custom-web-wallet.com"
+     >
    */
   customWalletAddress?: string;
 }

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -18,6 +18,7 @@ export interface BaseNetworkType {
 export interface AccountInfoSliceNetworkType extends BaseNetworkType {
   walletConnectBridgeAddress: string;
   walletConnectV2RelayAddress: string;
+  customWalletAddress?: string;
 }
 
 export interface NetworkType extends BaseNetworkType {


### PR DESCRIPTION
### Feature

### Root cause
Unable to connect to a custom web wallet provider

### Fix
Add `customWalletAddress` param to networkConfig.
The `customWalletAddress` property is used to override the default `walletAddress`.
This is useful when you want to use a custom wallet provider.
It overrides the network's wallet address, including the wallet address from the custom network config specified in the `DappProvider`.
example:

```
<WebWalletLoginButton
      {...otherLoginProps}
      customWalletAddress="https://custom-web-wallet.com"
     >
```

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
