### PR TITLE
[FIX] Added page reload on login redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- [Added page reload on login redirect](https://github.com/multiversx/mx-sdk-dapp/pull/944)
 ## [[v2.22.1]](https://github.com/multiversx/mx-sdk-dapp/pull/942)] - 2023-10-02
+
 - [Fixed `WebWalletLoginButtonPropsType` interface](https://github.com/multiversx/mx-sdk-dapp/pull/942)
+
 ## [[v2.22.0]](https://github.com/multiversx/mx-sdk-dapp/pull/941)] - 2023-10-02
+
 - [Added support for custom Web Wallet address](https://github.com/multiversx/mx-sdk-dapp/pull/940)
+
 ## [[v2.21.1]](https://github.com/multiversx/mx-sdk-dapp/pull/939)] - 2023-09-29
+
 - [Added `getDefaultCallbackUrl` helper](https://github.com/multiversx/mx-sdk-dapp/pull/936)
 - [Return native auth token when refreshing the token](https://github.com/multiversx/mx-sdk-dapp/pull/938)
 

--- a/src/UI/extension/ExtensionLoginButton/tests/ExtensionLoginButton.test.tsx
+++ b/src/UI/extension/ExtensionLoginButton/tests/ExtensionLoginButton.test.tsx
@@ -3,7 +3,6 @@ import { expect } from '@storybook/jest';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { rest } from 'msw';
 import {
-  mockWindowHistory,
   mockWindowLocation,
   renderWithProvider,
   server,
@@ -54,7 +53,6 @@ describe('ExtensionLoginButton tests', () => {
   beforeEach(() => {
     store.dispatch(logoutAction());
     mockWindowLocation();
-    mockWindowHistory();
   });
 
   it('should perform simple login and redirect', async () => {
@@ -69,11 +67,7 @@ describe('ExtensionLoginButton tests', () => {
     await checkIsLoggedInStore();
 
     await waitFor(() => {
-      expect(window.history.pushState).toHaveBeenCalledWith(
-        '',
-        '',
-        CALLBACK_ROUTE
-      );
+      expect(window.location.assign).toHaveBeenCalledWith(CALLBACK_ROUTE);
     });
   });
 
@@ -114,7 +108,7 @@ describe('ExtensionLoginButton tests', () => {
     await checkIsLoggedInStore();
 
     await waitFor(() => {
-      expect(window.history.pushState).toHaveBeenCalledTimes(0);
+      expect(window.location.assign).toHaveBeenCalledTimes(0);
       expect(onLoginRedirect).toHaveBeenCalledTimes(1);
       expect(onLoginRedirect).toHaveBeenCalledWith(CALLBACK_ROUTE, {
         address: testAddress,
@@ -147,11 +141,7 @@ describe('ExtensionLoginButton tests', () => {
         tokenLoginWithSignature
       );
 
-      expect(window.history.pushState).toHaveBeenCalledWith(
-        '',
-        '',
-        CALLBACK_ROUTE
-      );
+      expect(window.location.assign).toHaveBeenCalledWith(CALLBACK_ROUTE);
     });
   });
 
@@ -174,7 +164,7 @@ describe('ExtensionLoginButton tests', () => {
     fireEvent.click(loginButton);
 
     await waitFor(() => {
-      expect(window.history.pushState).toHaveBeenCalledTimes(0);
+      expect(window.location.assign).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/UI/ledger/LedgerLoginButton/tests/LedgerLoginButton.test.tsx
+++ b/src/UI/ledger/LedgerLoginButton/tests/LedgerLoginButton.test.tsx
@@ -7,8 +7,7 @@ import {
   renderWithProvider,
   server,
   testNetwork,
-  testAddress,
-  mockWindowHistory
+  testAddress
 } from '__mocks__';
 
 import { logoutAction } from 'reduxStore/commonActions';
@@ -48,7 +47,6 @@ describe('LedgerLoginButton tests', () => {
   beforeEach(async () => {
     store.dispatch(logoutAction());
     mockWindowLocation();
-    mockWindowHistory();
   });
 
   it('should perform simple login and redirect', async () => {
@@ -67,11 +65,7 @@ describe('LedgerLoginButton tests', () => {
     await checkIsLoggedInStore();
 
     await waitFor(() => {
-      expect(window.history.pushState).toHaveBeenCalledWith(
-        '',
-        '',
-        CALLBACK_ROUTE
-      );
+      expect(window.location.assign).toHaveBeenCalledWith(CALLBACK_ROUTE);
     });
   });
 
@@ -107,7 +101,7 @@ describe('LedgerLoginButton tests', () => {
     await checkIsLoggedInStore();
 
     await waitFor(() => {
-      expect(window.history.pushState).toHaveBeenCalledTimes(0);
+      expect(window.location.assign).toHaveBeenCalledTimes(0);
       expect(onLoginRedirect).toHaveBeenCalledTimes(1);
       expect(onLoginRedirect).toHaveBeenCalledWith(CALLBACK_ROUTE, {
         address: testAddress,
@@ -143,11 +137,7 @@ describe('LedgerLoginButton tests', () => {
         tokenLoginWithSignature
       );
 
-      expect(window.history.pushState).toHaveBeenCalledWith(
-        '',
-        '',
-        CALLBACK_ROUTE
-      );
+      expect(window.location.assign).toHaveBeenCalledWith(CALLBACK_ROUTE);
     });
   });
 
@@ -172,7 +162,7 @@ describe('LedgerLoginButton tests', () => {
     await ledgerLogin(methods);
 
     await waitFor(() => {
-      expect(window.history.pushState).toHaveBeenCalledTimes(0);
+      expect(window.location.assign).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/src/utils/internal/optionalRedirect.ts
+++ b/src/utils/internal/optionalRedirect.ts
@@ -1,4 +1,3 @@
-import { getWindowLocation } from 'utils/window/getWindowLocation';
 import { OnLoginRedirectOptionsType, OnProviderLoginType } from '../../types';
 import { safeRedirect } from '../redirect';
 
@@ -22,13 +21,9 @@ export function optionalRedirect({
       return onLoginRedirect(callbackRoute, options);
     }
 
-    const { pathname } = getWindowLocation();
-
-    if (!pathname.includes(callbackRoute)) {
-      safeRedirect({
-        url: callbackRoute,
-        timeout: DEFAULT_TIMEOUT
-      });
-    }
+    safeRedirect({
+      url: callbackRoute,
+      timeout: DEFAULT_TIMEOUT
+    });
   }
 }

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -89,7 +89,7 @@ function redirectToCallbackUrl(
     if (typeof onRedirect === 'function') {
       onRedirect(callbackUrl);
     } else {
-      safeRedirect({ url: callbackUrl, shouldForcePageReload: true });
+      safeRedirect({ url: callbackUrl });
     }
   }
 }

--- a/src/utils/redirect.ts
+++ b/src/utils/redirect.ts
@@ -5,11 +5,9 @@ export const preventRedirects = (shouldPreventRedirect = true) => {
 };
 
 export const safeRedirect = ({
-  shouldForcePageReload,
   timeout = 0,
   url
 }: {
-  shouldForcePageReload?: boolean;
   timeout?: number;
   url: string;
 }) => {
@@ -17,13 +15,6 @@ export const safeRedirect = ({
     setTimeout(() => {
       if (!window) {
         return;
-      }
-
-      // Navigate to callbackUrl without page refresh if we are in the same origin
-      const isSameOriginRedirect = url?.startsWith('/');
-
-      if (isSameOriginRedirect && !shouldForcePageReload) {
-        return window.history.pushState('', '', url);
       }
 
       return window.location.assign(url);


### PR DESCRIPTION
### Issue
After login, the page does not redirect correctly to the specified `callbackRoute`

### Reproduce
Issue exists on version `2.22.1` of sdk-dapp.

### Root cause
Redirect is done with `window.history.pushState` instead of `window.location.assign` which seems to have undesirable side effects.

### Fix
Replace `window.history.pushState` with `window.location.assign` in the `safeRedirect` helper

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[x] Unit tests
