### PR TITLE
add used indexes to addressTable component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
+- [Add used indexes to addressTable component](https://github.com/multiversx/mx-sdk-dapp/pull/948)
+
 ## [[v2.22.2]](https://github.com/multiversx/mx-sdk-dapp/pull/947)] - 2023-10-12
 - [Added `ESDTNFTBurn` to `getTokenFromData` helper](https://github.com/multiversx/mx-sdk-dapp/pull/946)
 - [Added page reload on login redirect](https://github.com/multiversx/mx-sdk-dapp/pull/944)

--- a/src/UI/ledger/LedgerLoginContainer/AddressRow/AddressRow.tsx
+++ b/src/UI/ledger/LedgerLoginContainer/AddressRow/AddressRow.tsx
@@ -16,6 +16,7 @@ export interface AddressRowPropsType extends WithClassnameType {
   balance: string;
   onSelectAddress: (address: { address: string; index: number } | null) => void;
   ledgerModalTableSelectedItemClassName?: string;
+  disabled: boolean;
 }
 
 export const AddressRow = ({
@@ -25,7 +26,8 @@ export const AddressRow = ({
   selectedAddress,
   onSelectAddress,
   className = 'dapp-ledger-address-row',
-  ledgerModalTableSelectedItemClassName
+  ledgerModalTableSelectedItemClassName,
+  disabled = false
 }: AddressRowPropsType) => {
   const handleChange = (event: SyntheticEvent) => {
     const { checked } = event.target as HTMLInputElement;
@@ -48,10 +50,15 @@ export const AddressRow = ({
         className
       )}
     >
-      <div className={styles.ledgerAddressTableBodyItemData}>
+      <div
+        className={`${styles.ledgerAddressTableBodyItemData} ${classNames({
+          disabled
+        })}`}
+      >
         <input
           type='radio'
           id={`check_${index}`}
+          disabled={disabled}
           data-testid={`check_${index}`}
           onChange={handleChange}
           role='button'

--- a/src/UI/ledger/LedgerLoginContainer/AddressRow/AddressRow.tsx
+++ b/src/UI/ledger/LedgerLoginContainer/AddressRow/AddressRow.tsx
@@ -51,9 +51,9 @@ export const AddressRow = ({
       )}
     >
       <div
-        className={`${styles.ledgerAddressTableBodyItemData} ${classNames({
+        className={classNames(styles.ledgerAddressTableBodyItemData, {
           disabled
-        })}`}
+        })}
       >
         <input
           type='radio'

--- a/src/UI/ledger/LedgerLoginContainer/AddressTable/AddressTable.tsx
+++ b/src/UI/ledger/LedgerLoginContainer/AddressTable/AddressTable.tsx
@@ -21,6 +21,7 @@ const ADDRESSES_PER_PAGE = 10;
 
 export interface AddressTablePropsType extends WithClassnameType {
   accounts: string[];
+  usedIndexes: number[];
   addressTableClassNames?: {
     ledgerModalTitleClassName?: string;
     ledgerModalSubtitleClassName?: string;
@@ -54,8 +55,10 @@ export const AddressTable = ({
   onGoToPrevPage,
   onSelectAddress,
   selectedAddress,
-  startIndex
+  startIndex,
+  usedIndexes = []
 }: AddressTablePropsType) => {
+  console.log('used indexes are: ', usedIndexes);
   const {
     ledgerModalTitleClassName,
     ledgerModalSubtitleClassName,
@@ -69,6 +72,15 @@ export const AddressTable = ({
   const [accountsWithBalance, setAccountsWithBalance] = useState<
     Array<{ address: string; balance: string }>
   >([]);
+
+  const getFirstUnusedIndex = () => {
+    let indexToCheck = 0;
+    while (usedIndexes.includes(indexToCheck)) {
+      indexToCheck++;
+    }
+    return indexToCheck;
+  };
+
   useEffect(() => {
     const isAccountsLoaded = accounts.length > 0 && !loading;
 
@@ -78,7 +90,7 @@ export const AddressTable = ({
     const shouldSelectFirstAddress =
       isAccountsLoaded && isFirstPageAndNoAddressSelected;
     if (shouldSelectFirstAddress) {
-      const index = 0;
+      const index = getFirstUnusedIndex();
       const address = accounts[index];
       onSelectAddress({ address, index });
     }
@@ -171,6 +183,7 @@ export const AddressTable = ({
               <AddressRow
                 address={address}
                 balance={balance}
+                disabled={usedIndexes.includes(index)}
                 key={index + startIndex * ADDRESSES_PER_PAGE}
                 index={index + startIndex * ADDRESSES_PER_PAGE}
                 selectedAddress={selectedAddress}

--- a/src/UI/ledger/LedgerLoginContainer/AddressTable/AddressTable.tsx
+++ b/src/UI/ledger/LedgerLoginContainer/AddressTable/AddressTable.tsx
@@ -56,9 +56,8 @@ export const AddressTable = ({
   onSelectAddress,
   selectedAddress,
   startIndex,
-  usedIndexes = []
+  disabledIndexes = []
 }: AddressTablePropsType) => {
-  console.log('used indexes are: ', usedIndexes);
   const {
     ledgerModalTitleClassName,
     ledgerModalSubtitleClassName,
@@ -75,7 +74,7 @@ export const AddressTable = ({
 
   const getFirstUnusedIndex = () => {
     let indexToCheck = 0;
-    while (usedIndexes.includes(indexToCheck)) {
+    while (disabledIndexes.includes(indexToCheck)) {
       indexToCheck++;
     }
     return indexToCheck;
@@ -183,7 +182,7 @@ export const AddressTable = ({
               <AddressRow
                 address={address}
                 balance={balance}
-                disabled={usedIndexes.includes(index)}
+                disabled={disabledIndexes.includes(index)}
                 key={index + startIndex * ADDRESSES_PER_PAGE}
                 index={index + startIndex * ADDRESSES_PER_PAGE}
                 selectedAddress={selectedAddress}


### PR DESCRIPTION
###Feature
Add used indexes to AddressTable component

### Reproduce
-

### Root cause
-
### Fix
-
### Additional changes
Allows passing an used indexes array to addressTable component. This indexes will be disabled in the component

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
