### PR TITLE
Fixed multi-sign step blocked in loading state after first step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
+
+- [Fixed multi-sign step blocked in loading state after first step](https://github.com/multiversx/mx-sdk-dapp/pull/952)
 
 ## [[v2.22.3]](https://github.com/multiversx/mx-sdk-dapp/pull/949)] - 2023-10-12
 - [Add used indexes to addressTable component](https://github.com/multiversx/mx-sdk-dapp/pull/948)

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
@@ -52,12 +52,7 @@ export const SignStep = (props: SignStepType) => {
   }`;
 
   useEffect(() => {
-    const isCurrentNonceRegistered =
-      Object.keys(nonceDataStepMap).includes(currentNonceData);
-    const isCurrentStepRegistered =
-      Object.values(nonceDataStepMap).includes(currentStep);
-
-    if (isCurrentNonceRegistered || isCurrentStepRegistered) {
+    if (nonceDataStepMap[currentNonceData] === currentStep) {
       return;
     }
 

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/SignWithDeviceModal.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/SignWithDeviceModal.tsx
@@ -19,22 +19,24 @@ export const SignWithDeviceModal = ({
   const { address } = useGetAccount();
 
   const {
-    onSignTransaction,
-    onPrev,
     allTransactions,
-    waitingForDevice,
-    onAbort,
-    isLastTransaction,
-    signedTransactions,
-    setSignedTransactions,
-    currentStep,
     callbackRoute,
-    currentTransaction
+    currentStep,
+    currentTransaction,
+    isLastTransaction,
+    isSigning,
+    onAbort,
+    onPrev,
+    onSignTransaction,
+    setSignedTransactions,
+    signedTransactions,
+    waitingForDevice
   } = useSignTransactionsWithDevice({
     onCancel: handleClose,
     verifyReceiverScam,
     hasGuardianScreen: Boolean(GuardianScreen)
   });
+
   const classes = {
     wrapper: classNames(styles.modalContainer, styles.walletConnect, className),
     container: classNames(globalStyles.card, globalStyles.container),
@@ -51,22 +53,23 @@ export const SignWithDeviceModal = ({
     >
       <div className={classes.cardBody}>
         <SignStep
-          address={address}
-          onSignTransaction={onSignTransaction}
-          allTransactions={allTransactions}
-          onPrev={onPrev}
           GuardianScreen={GuardianScreen}
-          signedTransactions={signedTransactions}
-          setSignedTransactions={setSignedTransactions}
-          waitingForDevice={waitingForDevice}
-          currentStep={currentStep}
-          isLastTransaction={isLastTransaction}
+          address={address}
+          allTransactions={allTransactions}
           callbackRoute={callbackRoute}
+          currentStep={currentStep}
           currentTransaction={currentTransaction}
-          handleClose={onAbort}
           error={error}
-          title={title}
+          handleClose={onAbort}
+          isLastTransaction={isLastTransaction}
+          isSigning={isSigning}
+          onPrev={onPrev}
+          onSignTransaction={onSignTransaction}
+          setSignedTransactions={setSignedTransactions}
           signStepInnerClasses={signStepInnerClasses}
+          signedTransactions={signedTransactions}
+          title={title}
+          waitingForDevice={waitingForDevice}
         />
       </div>
     </ModalContainer>

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/signWithDeviceModal.types.ts
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/signWithDeviceModal.types.ts
@@ -23,13 +23,14 @@ export interface SignStepInnerClassesType {
 export interface SignStepPropsType
   extends WithClassnameType,
     GuardianScreenType {
-  handleClose: () => void;
   GuardianScreen?: SignPropsType['GuardianScreen'];
-  waitingForDevice: boolean;
-  error: string | null;
+  allTransactions: MultiSignTransactionType[];
   callbackRoute?: string;
   currentStep: number;
   currentTransaction: ActiveLedgerTransactionType | null;
-  allTransactions: MultiSignTransactionType[];
+  error: string | null;
+  handleClose: () => void;
   isLastTransaction: boolean;
+  isSigning: boolean;
+  waitingForDevice: boolean;
 }

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, Dispatch, SetStateAction } from 'react';
 import { Transaction } from '@multiversx/sdk-core';
 import { getScamAddressData } from 'apiCalls/getScamAddressData';
 
@@ -36,19 +36,20 @@ export interface UseSignTransactionsWithDevicePropsType {
 
 export interface UseSignTransactionsWithDeviceReturnType {
   allTransactions: MultiSignTransactionType[];
-  onSignTransaction: () => void;
+  callbackRoute?: string;
+  currentStep: number;
+  currentTransaction: ActiveLedgerTransactionType | null;
+  isLastTransaction: boolean;
+  isSigning: boolean;
+  onAbort: () => void;
   onNext: () => void;
   onPrev: () => void;
-  onAbort: () => void;
-  waitingForDevice: boolean;
-  isLastTransaction: boolean;
-  currentStep: number;
-  signedTransactions?: DeviceSignedTransactions;
-  setSignedTransactions?: React.Dispatch<
-    React.SetStateAction<DeviceSignedTransactions | undefined>
+  onSignTransaction: () => void;
+  setSignedTransactions?: Dispatch<
+    SetStateAction<DeviceSignedTransactions | undefined>
   >;
-  currentTransaction: ActiveLedgerTransactionType | null;
-  callbackRoute?: string;
+  signedTransactions?: DeviceSignedTransactions;
+  waitingForDevice: boolean;
 }
 
 export function useSignTransactionsWithDevice(


### PR DESCRIPTION
### Issue
Sign modal is stuck in loading phase after signing.

### Reproduce
Issue exists on version `2.22.3` of sdk-dapp. Navigate to web wallet at this [hook URL](https://devnet-wallet.multiversx.com/hook/sign?nonce%5B0%5D=786&value%5B0%5D=0&receiver%5B0%5D=erd1uv40ahysflse896x4ktnh6ecx43u7cmy9wnxnvcyp7deg299a4sq6vaywa&sender%5B0%5D=erd1uv40ahysflse896x4ktnh6ecx43u7cmy9wnxnvcyp7deg299a4sq6vaywa&gasPrice%5B0%5D=1000000000&gasLimit%5B0%5D=7000000&data%5B0%5D=MultiESDTNFTTransfer%40000000000000000005006704c51b25a956ddbc643189ba7945b413890d4f0fd6%4002%40444d452d626465326238%4001%4001%40444d452d626465326238%4001%4001%406e6674446973747269627574696f6e%40ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09%40ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09&chainID%5B0%5D=D&version%5B0%5D=1&callbackUrl=http%3A%2F%2Flocalhost%3A4200%2Fapp%2Ftickets%2F8daa71d8-91bd-4892-9696-914bbfc36317%2Ftickets%2FDME-bde2b8-01%2Fairdrops%3FsignSession%3D1697019349965) and try to sign

### Root cause
The next step was skipped from setting after click

### Fix
Skip the state update with the `currentStep` only if the step is set for the `currentNonceData` 

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
