### PR TITLE
Fixed `MultiESDTNFTTransfer` data field highlight and signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+- [Fixed `MultiESDTNFTTransfer` data field highlight and signing](https://github.com/multiversx/mx-sdk-dapp/pull/960)
+
 ## [[v2.22.3]](https://github.com/multiversx/mx-sdk-dapp/pull/949)] - 2023-10-12
 - [Add used indexes to addressTable component](https://github.com/multiversx/mx-sdk-dapp/pull/948)
 

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
@@ -49,7 +49,7 @@ export const SignStep = (props: SignStepType) => {
   const currentNonce = currentTransaction.transaction.getNonce().valueOf();
   const currentNonceData = `${currentNonce.toString()}_${
     currentTransaction.transactionTokenInfo.multiTxData
-  }`;
+  }_${currentTransaction.transactionIndex}`;
 
   useEffect(() => {
     const isCurrentNonceRegistered =

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/SignStepBody.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/SignStepBody.tsx
@@ -171,7 +171,7 @@ export const SignStepBody = ({
               transactionDataInputValueClassName: inputValueClassName
             }}
             isScCall={!tokenId}
-            txIndex={currentTransaction.transactionIndex}
+            transactionIndex={currentTransaction.transactionIndex}
           />
         )}
 

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/SignStepBody.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/SignStepBody.tsx
@@ -119,6 +119,8 @@ export const SignStepBody = ({
   const shouldShowAmount =
     isEgld || isEsdt || (Boolean(type) && type !== NftEnumType.NonFungibleESDT);
 
+  const data = currentTransaction.transaction.getData().toString();
+
   return (
     <div className={styles.summary}>
       <div className={styles.fields}>
@@ -159,16 +161,17 @@ export const SignStepBody = ({
           </div>
         </div>
 
-        {currentTransaction.transaction.getData() && (
+        {data && (
           <TransactionData
-            isScCall={!tokenId}
-            data={currentTransaction.transaction.getData().toString()}
-            highlight={multiTxData}
             className={inputGroupClassName}
+            data={data}
+            highlight={multiTxData}
             innerTransactionDataClasses={{
               transactionDataInputLabelClassName: inputLabelClassName,
               transactionDataInputValueClassName: inputValueClassName
             }}
+            isScCall={!tokenId}
+            txIndex={currentTransaction.transactionIndex}
           />
         )}
 

--- a/src/UI/TransactionData/TransactionData.tsx
+++ b/src/UI/TransactionData/TransactionData.tsx
@@ -5,12 +5,18 @@ import globalStyles from 'assets/sass/main.scss';
 
 import { DataTestIdsEnum, N_A } from 'constants/index';
 import { decodePart } from 'utils/decoders/decodePart';
+import { getUnHighlightedDataFieldParts } from 'utils/transactions/getUnHighlightedDataFieldParts';
 import { WithClassnameType } from '../types';
 
 import styles from './TransactionDataStyles.scss';
 
-const allOccurences = (sourceStr: string, searchStr: string) =>
-  [...sourceStr.matchAll(new RegExp(searchStr, 'gi'))].map((a) => a.index);
+const allOccurences = (sourceStr: string, searchStr: string) => {
+  const occurrences = [...sourceStr.matchAll(new RegExp(searchStr, 'gi'))].map(
+    (result) => result.index
+  );
+
+  return occurrences.filter((search) => Number.isFinite(search)) as number[];
+};
 
 export interface TransactionDataPropsType extends WithClassnameType {
   data: string;
@@ -20,7 +26,7 @@ export interface TransactionDataPropsType extends WithClassnameType {
     transactionDataInputLabelClassName?: string;
     transactionDataInputValueClassName?: string;
   };
-  txIndex: number;
+  transactionIndex: number;
 }
 
 export const TransactionData = ({
@@ -29,7 +35,7 @@ export const TransactionData = ({
   highlight,
   innerTransactionDataClasses,
   isScCall,
-  txIndex
+  transactionIndex
 }: TransactionDataPropsType) => {
   const {
     transactionDataInputLabelClassName,
@@ -71,10 +77,12 @@ export const TransactionData = ({
       }
 
       default: {
-        const highlightIndex = occurrences[txIndex] || data.indexOf(highlight);
-        const highlightLength = highlight.length;
-        const start = data.slice(0, highlightIndex);
-        const end = data.slice(highlightIndex + highlightLength);
+        const { start, end } = getUnHighlightedDataFieldParts({
+          occurrences,
+          transactionIndex,
+          data,
+          highlight
+        });
 
         output = (
           <>

--- a/src/UI/TransactionData/TransactionData.tsx
+++ b/src/UI/TransactionData/TransactionData.tsx
@@ -48,7 +48,7 @@ export const TransactionData = ({
   if (showHighlight) {
     switch (true) {
       case data.startsWith(highlight): {
-        const [_, rest] = data.split(highlight);
+        const [, rest] = data.split(highlight);
 
         output = (
           <>

--- a/src/UI/TransactionData/TransactionData.tsx
+++ b/src/UI/TransactionData/TransactionData.tsx
@@ -20,14 +20,16 @@ export interface TransactionDataPropsType extends WithClassnameType {
     transactionDataInputLabelClassName?: string;
     transactionDataInputValueClassName?: string;
   };
+  txIndex: number;
 }
 
 export const TransactionData = ({
+  className = 'dapp-transaction-data',
   data,
   highlight,
+  innerTransactionDataClasses,
   isScCall,
-  className = 'dapp-transaction-data',
-  innerTransactionDataClasses
+  txIndex
 }: TransactionDataPropsType) => {
   const {
     transactionDataInputLabelClassName,
@@ -39,10 +41,15 @@ export const TransactionData = ({
   const [encodedScCall, ...remainingDataFields] =
     highlight && isScCall ? highlight.split('@') : [];
 
-  if (data && highlight && allOccurences(data, highlight).length === 1) {
+  const isHighlightedData = data && highlight;
+  const occurrences = isHighlightedData ? allOccurences(data, highlight) : [];
+  const showHighlight = isHighlightedData && occurrences.length > 0;
+
+  if (showHighlight) {
     switch (true) {
       case data.startsWith(highlight): {
-        const [, rest] = data.split(highlight);
+        const [_, rest] = data.split(highlight);
+
         output = (
           <>
             {highlight}
@@ -53,6 +60,7 @@ export const TransactionData = ({
       }
       case data.endsWith(highlight): {
         const [rest] = data.split(highlight);
+
         output = (
           <>
             <span className={globalStyles.textMuted}>{rest}</span>
@@ -63,7 +71,10 @@ export const TransactionData = ({
       }
 
       default: {
-        const [start, end] = data.split(highlight);
+        const highlightIndex = occurrences[txIndex] || data.indexOf(highlight);
+        const highlightLength = highlight.length;
+        const start = data.slice(0, highlightIndex);
+        const end = data.slice(highlightIndex + highlightLength);
 
         output = (
           <>

--- a/src/hooks/transactions/useParseMultiEsdtTransferData.ts
+++ b/src/hooks/transactions/useParseMultiEsdtTransferData.ts
@@ -113,6 +113,7 @@ export function useParseMultiEsdtTransferData({
           });
         }
       });
+
       setAllTransactions(allTxs);
     }
   }

--- a/src/hooks/transactions/useSignMultipleTransactions.tsx
+++ b/src/hooks/transactions/useSignMultipleTransactions.tsx
@@ -99,12 +99,13 @@ export function useSignMultipleTransactions({
       return;
     }
 
-    const { transaction, multiTxData } = tx;
+    const { transaction, multiTxData, transactionIndex } = tx;
     const dataField = transaction.getData().toString();
     const transactionTokenInfo = getTxInfoByDataField(
       transaction.getData().toString(),
       multiTxData
     );
+
     const { tokenId } = transactionTokenInfo;
     const receiver = transaction.getReceiver().toString();
     const sender = transaction.getSender().toString();
@@ -137,7 +138,8 @@ export function useSignMultipleTransactions({
       receiverScamInfo: verifiedAddresses[receiver]?.info || null,
       transactionTokenInfo,
       isTokenTransaction,
-      dataField
+      dataField,
+      transactionIndex
     });
   }
 

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -162,11 +162,12 @@ export interface SignTransactionsPropsType {
 }
 
 export interface ActiveLedgerTransactionType {
-  transaction: Transaction;
-  transactionTokenInfo: TransactionDataTokenType;
-  isTokenTransaction: boolean;
   dataField: string;
+  isTokenTransaction: boolean;
   receiverScamInfo: string | null;
+  transaction: Transaction;
+  transactionIndex: number;
+  transactionTokenInfo: TransactionDataTokenType;
 }
 
 export interface SmartContractResult {

--- a/src/utils/transactions/getUnHighlightedDataFieldParts.ts
+++ b/src/utils/transactions/getUnHighlightedDataFieldParts.ts
@@ -1,0 +1,22 @@
+export const getUnHighlightedDataFieldParts = ({
+  data,
+  highlight,
+  occurrences,
+  transactionIndex
+}: {
+  data: string;
+  highlight: string;
+  occurrences: number[];
+  transactionIndex: number;
+}) => {
+  const highlightIndex =
+    occurrences[transactionIndex] || data.indexOf(highlight);
+  const highlightLength = highlight.length;
+  const start = data.slice(0, highlightIndex);
+  const end = data.slice(highlightIndex + highlightLength);
+
+  return {
+    start,
+    end
+  };
+};

--- a/src/utils/transactions/index.ts
+++ b/src/utils/transactions/index.ts
@@ -4,6 +4,7 @@ export * from './getAreTransactionsOnSameShard';
 export * from './getInterpretedTransaction';
 export * from './getTokenFromData';
 export * from './getTransactionLink';
+export * from './getUnHighlightedDataFieldParts';
 export * from './isTokenTransfer';
 export * from './parseMultiEsdtTransferData';
 export * from './parseTransactionAfterSigning';

--- a/src/utils/transactions/parseMultiEsdtTransferData.ts
+++ b/src/utils/transactions/parseMultiEsdtTransferData.ts
@@ -3,7 +3,6 @@ import { MultiEsdtTransactionType, TransactionTypesEnum } from 'types';
 import { decodePart } from 'utils/decoders/decodePart';
 import { getAllStringOccurrences } from '../getAllStringOccurrences';
 
-// TODO: add tests
 export function parseMultiEsdtTransferData(data?: string) {
   const transactions: MultiEsdtTransactionType[] = [];
   let contractCallDataIndex = 0;
@@ -15,8 +14,8 @@ export function parseMultiEsdtTransferData(data?: string) {
       const [, receiver, encodedTxCount, ...rest] = data?.split('@');
       if (receiver) {
         const txCount = new BigNumber(encodedTxCount, 16).toNumber();
-
         let itemIndex = 0;
+
         for (let txIndex = 0; txIndex < txCount; txIndex++) {
           const transaction: MultiEsdtTransactionType = {
             type: TransactionTypesEnum.nftTransaction,

--- a/src/utils/transactions/tests/getUnHighlightedDataFieldParts.test.ts
+++ b/src/utils/transactions/tests/getUnHighlightedDataFieldParts.test.ts
@@ -1,0 +1,93 @@
+import { getUnHighlightedDataFieldParts } from '../getUnHighlightedDataFieldParts';
+
+describe('getUnHighlightedDataFieldParts tests', () => {
+  it('should show correctly for first occurrence when present in the middle', () => {
+    const firstOccurrenceIndex = 5;
+    const lastOccurrenceIndex = 11;
+
+    const { start, end } = getUnHighlightedDataFieldParts({
+      data: 'StartMiddleMiddleEnd',
+      highlight: 'Middle',
+      occurrences: [firstOccurrenceIndex, lastOccurrenceIndex],
+      transactionIndex: 0
+    });
+
+    expect(start).toStrictEqual('Start');
+    expect(end).toStrictEqual('MiddleEnd');
+  });
+
+  it('should show correctly for last occurrence when present in the middle', () => {
+    const firstOccurrenceIndex = 5;
+    const lastOccurrenceIndex = 11;
+
+    const { start, end } = getUnHighlightedDataFieldParts({
+      data: 'StartMiddleMiddleEnd',
+      highlight: 'Middle',
+      occurrences: [firstOccurrenceIndex, lastOccurrenceIndex],
+      transactionIndex: 1
+    });
+
+    expect(start).toStrictEqual('StartMiddle');
+    expect(end).toStrictEqual('End');
+  });
+
+  it('should show correctly for first occurrence when present in the beginning', () => {
+    const firstOccurrenceIndex = 0;
+    const lastOccurrenceIndex = 6;
+
+    const { start, end } = getUnHighlightedDataFieldParts({
+      data: 'MiddleMiddleEnd',
+      highlight: 'Middle',
+      occurrences: [firstOccurrenceIndex, lastOccurrenceIndex],
+      transactionIndex: 0
+    });
+
+    expect(start).toStrictEqual('');
+    expect(end).toStrictEqual('MiddleEnd');
+  });
+
+  it('should show correctly for second occurrence when present in the beginning', () => {
+    const firstOccurrenceIndex = 0;
+    const lastOccurrenceIndex = 6;
+
+    const { start, end } = getUnHighlightedDataFieldParts({
+      data: 'MiddleMiddleEnd',
+      highlight: 'Middle',
+      occurrences: [firstOccurrenceIndex, lastOccurrenceIndex],
+      transactionIndex: 1
+    });
+
+    expect(start).toStrictEqual('Middle');
+    expect(end).toStrictEqual('End');
+  });
+
+  it('should show correctly for first occurrence when present in the end', () => {
+    const firstOccurrenceIndex = 5;
+    const lastOccurrenceIndex = 11;
+
+    const { start, end } = getUnHighlightedDataFieldParts({
+      data: 'StartMiddleMiddle',
+      highlight: 'Middle',
+      occurrences: [firstOccurrenceIndex, lastOccurrenceIndex],
+      transactionIndex: 0
+    });
+
+    expect(start).toStrictEqual('Start');
+    expect(end).toStrictEqual('Middle');
+  });
+
+  it('should show correctly for second occurrence when present in the end', () => {
+    const firstOccurrenceIndex = 5;
+    const lastOccurrenceIndex = 11;
+
+    const { start, end } = getUnHighlightedDataFieldParts({
+      data: 'StartMiddleMiddle',
+      highlight: 'Middle',
+      occurrences: [firstOccurrenceIndex, lastOccurrenceIndex],
+      transactionIndex: 1
+    });
+
+    expect(start).toStrictEqual('StartMiddle');
+    expect(end).toStrictEqual('');
+  });
+});

--- a/src/utils/transactions/tests/parseMultiEsdtTransferData.test.ts
+++ b/src/utils/transactions/tests/parseMultiEsdtTransferData.test.ts
@@ -72,12 +72,9 @@ const two = {
 };
 const three = {
   data: removeWhiteSpaces(`MultiESDTNFTTransfer@000000000000000005003a6b2c77e799c53499791de274ebee24558681aa10fb
-  @02@534649544c4547454e442d356461396464
-  @0ead
-  @01
-  @534649542d616562633930
-  @00
-  @01e0524e2357d3c000
+  @02
+  @534649544c4547454e442d356461396464@0ead@01
+  @534649542d616562633930@00@01e0524e2357d3c000
   @75706772616465@6d657461646174613a626166796265696168776b34323576763669647767736a356f74356c32716a737170656c67366c716a6779777733747563727135777a62766664712f333036302e6a736f6e@7618623408A6A242813A40E471F2CE707599F0C12DA0790DCBB6305A3993F5B65771FCCB4EE925772E348458AAD916504F806F97485490F59C27EF56236A4801`),
   sft: {
     amount: '1',
@@ -103,6 +100,33 @@ const three = {
     type: 'scCall'
   }
 };
+
+const four = {
+  data: removeWhiteSpaces(`MultiESDTNFTTransfer
+  @000000000000000005006704c51b25a956ddbc643189ba7945b413890d4f0fd6
+  @02
+  @444d452d626465326238@01@01
+  @444d452d626465326238@01@01
+  @6e6674446973747269627574696f6e
+  @ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09
+  @ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09`),
+  nft: {
+    amount: '1',
+    data: '444d452d626465326238@01@01',
+    nonce: '01',
+    receiver:
+      '000000000000000005006704c51b25a956ddbc643189ba7945b413890d4f0fd6',
+    token: 'DME-bde2b8',
+    type: 'nftTransaction'
+  },
+  ssCall: {
+    data: '6e6674446973747269627574696f6e@ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09@ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09',
+    receiver:
+      '000000000000000005006704c51b25a956ddbc643189ba7945b413890d4f0fd6',
+    type: 'scCall'
+  }
+};
+
 describe('parseMultiEsdtTransferData tests', () => {
   test('Interprets data with scCall', () => {
     const response = [one.esdt, one.sft1, one.sft2, one.scCall];
@@ -136,6 +160,13 @@ describe('parseMultiEsdtTransferData tests', () => {
   test('Interprets data with two ESDT and NFT transactions', () => {
     const result = parseMultiEsdtTransferData(three.data);
     const response = [three.sft, three.esdt, three.scCall];
+    expect(result).toEqual(response);
+  });
+  test('Interprets data with two identical NFT transactions', () => {
+    const result = parseMultiEsdtTransferData(
+      'MultiESDTNFTTransfer@000000000000000005006704c51b25a956ddbc643189ba7945b413890d4f0fd6@02@444d452d626465326238@01@01@444d452d626465326238@01@01@6e6674446973747269627574696f6e@ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09@ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09'
+    );
+    const response = [four.nft, four.nft, four.ssCall];
     expect(result).toEqual(response);
   });
 });


### PR DESCRIPTION
### Issue
Cannot sign a `MultiESDTNFTTransfer` and highlight is not showing the transaction data correctly.

### Reproduce
Issue exists on version `2.22.5` of sdk-dapp. Go to this [sign hook](https://devnet-wallet.multiversx.com/hook/sign?nonce%5B0%5D=786&value%5B0%5D=0&receiver%5B0%5D=erd1wh9c0sjr2xn8hzf02lwwcr4jk2s84tat9ud2kaq6zr7xzpvl9l5q8awmex&sender%5B0%5D=erd1wh9c0sjr2xn8hzf02lwwcr4jk2s84tat9ud2kaq6zr7xzpvl9l5q8awmex&gasPrice%5B0%5D=1000000000&gasLimit%5B0%5D=7000000&data%5B0%5D=MultiESDTNFTTransfer%40000000000000000005006704c51b25a956ddbc643189ba7945b413890d4f0fd6%4002%40444d452d626465326238%4001%4001%40444d452d626465326238%4001%4001%406e6674446973747269627574696f6e%40ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09%40ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09&chainID%5B0%5D=D&version%5B0%5D=1&callbackUrl=http%3A%2F%2Flocalhost%3A4200%2Fapp%2Ftickets%2F8daa71d8-91bd-4892-9696-914bbfc36317%2Ftickets%2FDME-bde2b8-01%2Fairdrops%3FsignSession%3D1697019349965) and try to sign.

### Root cause
The transaction data field has 2 identical tokens. This was not expected. This is the data field:

`MultiESDTNFTTransfer
@000000000000000005006704c51b25a956ddbc643189ba7945b413890d4f0fd6
  @02
  @444d452d626465326238@01@01
  @444d452d626465326238@01@01
  @6e6674446973747269627574696f6e
  @ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09
  @ee62513ef30aede25b3366b6e3219ee18084026f36d6105299ee9963b1338f09
`

### Fix
Take into consideration the `transactionIndex` when scoping the signed transaction token and when searching for the highlight string in the data field.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[x] Unit tests
