### PR TITLE
Fixed logout for wallet provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.24.2]](https://github.com/multiversx/mx-sdk-dapp/pull/975)] - 2023-11-28
+- [Fixed logout for wallet provider](https://github.com/multiversx/mx-sdk-dapp/pull/974)
+
 ## [[v2.24.1]](https://github.com/multiversx/mx-sdk-dapp/pull/973)] - 2023-11-28
 - [Fixed logout redirect loop](https://github.com/multiversx/mx-sdk-dapp/pull/973)
 

--- a/src/UI/UsdValue/UsdValue.tsx
+++ b/src/UI/UsdValue/UsdValue.tsx
@@ -21,7 +21,6 @@ const UsdValueComponent = ({
   addEqualSign,
   className,
   globalStyles,
-  styles,
   ...dataTestId
 }: UsdValueType & WithStylesImportType) => {
   const value = getUsdValue({

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -2,6 +2,7 @@ import { getAccountProvider, getProviderType } from 'providers';
 import { logoutAction } from 'reduxStore/commonActions';
 import { store } from 'reduxStore/store';
 import { LoginMethodsEnum } from 'types';
+import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { getAddress, getWebviewToken } from './account';
 import { preventRedirects, safeRedirect } from './redirect';
 import { storage } from './storage';
@@ -29,20 +30,26 @@ export async function logout(
   onRedirect?: (callbackUrl?: string) => void,
   shouldAttemptRelogin = Boolean(getWebviewToken())
 ) {
+  const isLoggedIn = getIsLoggedIn();
   const provider = getAccountProvider();
   const providerType = getProviderType(provider);
   const isWalletProvider = providerType === LoginMethodsEnum.wallet;
+
+  console.log({ providerType, isLoggedIn });
 
   if (shouldAttemptRelogin && provider?.relogin != null) {
     return await provider.relogin();
   }
 
-  const url = addOriginToLocationPath(callbackUrl);
-
   if (isWalletProvider) {
+    if (!isLoggedIn) {
+      return;
+    }
+
     preventRedirects();
   }
 
+  const url = addOriginToLocationPath(callbackUrl);
   store.dispatch(logoutAction());
 
   try {
@@ -59,10 +66,7 @@ export async function logout(
 
   try {
     if (isWalletProvider) {
-      // allow Redux clearing its state before navigation
-      setTimeout(() => {
-        provider.logout({ callbackUrl: url });
-      });
+      await provider.logout({ callbackUrl: url });
     } else {
       await provider.logout({ callbackUrl: url });
       redirectToCallbackUrl(url, onRedirect);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,9 +7305,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.535:
-  version "1.4.594"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.594.tgz#f69f207fba80735a44a988df42f3f439115d0515"
-  integrity sha512-xT1HVAu5xFn7bDfkjGQi9dNpMqGchUkebwf1GL7cZN32NSwwlHRPMSDJ1KN6HkS0bWUtndbSQZqvpQftKG2uFQ==
+  version "1.4.595"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.595.tgz#fa33309eb9aabb7426915f8e166ec60f664e9ad4"
+  integrity sha512-+ozvXuamBhDOKvMNUQvecxfbyICmIAwS4GpLmR0bsiSBlGnLaOcs2Cj7J8XSbW+YEaN3Xl3ffgpm+srTUWFwFQ==
 
 element-resize-detector@^1.2.2:
   version "1.2.4"


### PR DESCRIPTION
### Issue
Logout is not working on wallet.

### Reproduce
Issue exists on version `2.24.1` of sdk-dapp.

### Root cause
Wallet provider is always present and the `provider.logout` is called no matter what, causing the wallet to constantly reload and navigate to logout hook.

### Fix
Avoid calling logout actions if not logged in.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
