### PR TITLE
Update Axios Interceptor to Support Auth for URL and BaseURL

### DIFF
--- a/src/wrappers/AxiosInterceptorContext/components/AxiosInterceptor.tsx
+++ b/src/wrappers/AxiosInterceptorContext/components/AxiosInterceptor.tsx
@@ -32,12 +32,17 @@ export const AxiosInterceptor = ({
     );
   };
 
+  const isUrlInAuthenticatedDomains = (url?: string) => {
+    if (!url) return false;
+    return authenticatedDomanis.some(domain => url.startsWith(domain));
+  };
+
   const setInterceptors = () => {
     axios.interceptors.request.eject(requestIdRef.current);
 
     requestIdRef.current = axios.interceptors.request.use(
       async (config) => {
-        if (authenticatedDomanis.includes(String(config?.baseURL))) {
+        if (authenticatedDomanis.includes(String(config?.baseURL)) || isUrlInAuthenticatedDomains(config.url)) {
           config.headers = {
             Authorization: `Bearer ${bearerToken}`
           };


### PR DESCRIPTION
Adjusted interceptor logic to authenticate requests based on both URL and BaseURL.

### Issue/Feature
The Axios Interceptor previously did not correctly authenticate requests when only the URL was set without the baseUrl, leading to inconsistencies in request handling.

### Reproduce
Issue exists on version `2.x` of sdk-dapp. The issue is observed when making API calls without a predefined BaseURL in Axios config. example: `await axios.get(`${MY_API}/hello`)`

### Root cause
The interceptor's logic was solely based on `config.baseURL`, which did not account for cases where the full URL is constructed differently or `baseURL` is not set.

### Fix
Added the `isUrlInAuthenticatedDomains` function to consider both `config.url` and `config.baseURL` when determining if a request belongs to an authenticated domain. This ensures proper authentication header inclusion in all scenarios.


### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[] Yes

### Testing
[x] User testing
[] Unit tests


