### PR TITLE
Fix issue in which signing a message with wallet would override message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fix sign message with web wallet provider](https://github.com/multiversx/mx-sdk-dapp/pull/985)
 ## [[v2.24.4]](https://github.com/multiversx/mx-sdk-dapp/pull/983)] - 2023-12-11
 - [Add entire dappConfig into redux store](https://github.com/multiversx/mx-sdk-dapp/pull/982)
 - [Fix CSS injection on SSR/Client side](https://github.com/multiversx/mx-sdk-dapp/pull/981)

--- a/src/hooks/signMessage/useSignMessage.ts
+++ b/src/hooks/signMessage/useSignMessage.ts
@@ -270,7 +270,7 @@ export const useSignMessage = () => {
         // Message was signed successfully
         dispatch(
           setSignSession({
-            sessionId: currentSessionId,
+            sessionId,
             signedSession: {
               signature,
               status

--- a/src/reduxStore/slices/signedMessageInfoSlice.ts
+++ b/src/reduxStore/slices/signedMessageInfoSlice.ts
@@ -57,7 +57,10 @@ export const signedMessageInfoSlice = createSlice({
       state.isSigning =
         signedSession.status === SignedMessageStatusesEnum.pending;
 
-      state.signedSessions[sessionId] = signedSession;
+      state.signedSessions[sessionId] = {
+        ...state.signedSessions[sessionId],
+        ...signedSession
+      };
     },
     setSignSessionState: (
       state: SignedMessageInfoStateType,


### PR DESCRIPTION
### Issue/Feature
Signing a message with web wallet provider it will override the signedSession object and it will remove the message.

### Reproduce
Issue exists on version `2.24.4` of sdk-dapp.

### Root cause
Overriding entire signedSession object.

### Fix
Update only the properties that needs to be updated.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
