### PR TITLE
Prevent provider logout when not logged in or initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Prevent provider logout when not logged in or initialized](https://github.com/multiversx/mx-sdk-dapp/pull/990)
+
 ## [[v2.25.0]](https://github.com/multiversx/mx-sdk-dapp/pull/988)] - 2023-12-14
 
 - [Added latest `axios` version](https://github.com/multiversx/mx-sdk-dapp/pull/989)

--- a/src/utils/window/tests/addOriginToLocationPath.test.ts
+++ b/src/utils/window/tests/addOriginToLocationPath.test.ts
@@ -53,4 +53,15 @@ describe('Add window origin to pathname', () => {
     const path = addOriginToLocationPath('/unlock');
     expect(path).toStrictEqual('https://multiversx.com/unlock');
   });
+
+  it('should return current origin if no parameter is specified', () => {
+    windowSpy.mockImplementation(() => ({
+      location: {
+        origin: 'https://multiversx.com'
+      }
+    }));
+
+    const path = addOriginToLocationPath();
+    expect(path).toStrictEqual('https://multiversx.com/');
+  });
 });


### PR DESCRIPTION
### Issue
There are cases when during the `logout` function the provider is `wallet` and not initialised, but it triggers logout and redirect to web wallet logout hook.

### Reproduce
Issue exists on version `2.25.0` of sdk-dapp.

### Fix
Prevent `provider.logout()` if the provider is not initialised and not logged in.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
