### PR TITLE
⚠️ Update sign message callbackRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Changed message signing URL to use `addOriginToLocationPath`](https://github.com/multiversx/mx-sdk-dapp/pull/994)
 
 ## [[v2.25.2]](https://github.com/multiversx/mx-sdk-dapp/pull/993)] - 2023-12-18
 

--- a/src/hooks/signMessage/useSignMessage.ts
+++ b/src/hooks/signMessage/useSignMessage.ts
@@ -28,6 +28,7 @@ import {
 import { parseNavigationParams } from 'utils/parseNavigationParams';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
 import {
+  addOriginToLocationPath,
   getAccountProvider,
   getAddress,
   removeSearchParamsFromUrl
@@ -103,9 +104,9 @@ export const useSignMessage = () => {
       return '';
     }
 
-    // Make sure callbackURL has sessionId
-    const callbackUrl = new URL(callbackRoute);
+    const callbackUrl = new URL(addOriginToLocationPath(callbackRoute));
 
+    // Make sure callbackURL has sessionId
     if (!callbackUrl.searchParams.get(SignedMessageQueryParamsEnum.sessionId)) {
       callbackUrl.searchParams.append(
         SignedMessageQueryParamsEnum.sessionId,


### PR DESCRIPTION
### Issue
Sign message callbackRoute needs entire URL as callbackRoute, which differs to callbackUrl defined for signing transactions 

### Reproduce
Issue exists on version `2.25.2` of sdk-dapp.

### Root cause
Current implementaiton:
`const callbackUrl = new URL(callbackRoute)` 

### Fix - ⚠️ Breaking change
Changed message signing url to use `addOriginToLocationPath` in order to build the URL.
All previous callbackRoutes which used the entire URL as callback will no longer work.
The new callbackRoute should be something like: `/dashboard`

### Additional changes

### Contains breaking changes
[] No

[x] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
