### PR TITLE
Toast for cancel sign message does not show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - [Fix cancel sign message toast](https://github.com/multiversx/mx-sdk-dapp/pull/995)
-- [Changed message signing URL to use `addOriginToLocationPath`](https://github.com/multiversx/mx-sdk-dapp/pull/994)
+- [⚠️ Breaking change: message signing URL to use `addOriginToLocationPath`](https://github.com/multiversx/mx-sdk-dapp/pull/994)
 
 ## [[v2.25.2]](https://github.com/multiversx/mx-sdk-dapp/pull/993)] - 2023-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fix cancel sign message toast](https://github.com/multiversx/mx-sdk-dapp/pull/995)
 - [Changed message signing URL to use `addOriginToLocationPath`](https://github.com/multiversx/mx-sdk-dapp/pull/994)
 
 ## [[v2.25.2]](https://github.com/multiversx/mx-sdk-dapp/pull/993)] - 2023-12-18

--- a/src/hooks/signMessage/useSignMessage.ts
+++ b/src/hooks/signMessage/useSignMessage.ts
@@ -14,7 +14,8 @@ import {
 import {
   clearSignedMessageInfo,
   setSignSession,
-  setSignSessionState
+  setSignSessionState,
+  setSignTransactionsCancelMessage
 } from 'reduxStore/slices';
 import {
   LoginMethodsEnum,
@@ -94,6 +95,7 @@ export const useSignMessage = () => {
         }
       })
     );
+    dispatch(setSignTransactionsCancelMessage(errorMessage));
   };
 
   const checkCallbackSessionId = (


### PR DESCRIPTION
### Issue
Cancelling a sign message does not display a toast with a specified message.

### Reproduce
Issue exists on version `2.25.2` of sdk-dapp.

### Root cause
Sign message URL params does not contain `signSession` in order for `useParseSignedTransactions` to be able to intercept and display the message.

### Fix
Instead of adding a new param for the URL, use directly `setSignTransactionsCancelMessage` in order to display the `errorMessage`.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
