### PR TITLE
Prevent logout action when not logged in or provider not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Added latest `axios` version](https://github.com/multiversx/mx-sdk-dapp/pull/989)
 - [Prevent redirect on logout if `callbackURL` is the current URL](https://github.com/multiversx/mx-sdk-dapp/pull/987)
 - [Fix sign message with web wallet provider](https://github.com/multiversx/mx-sdk-dapp/pull/985)
-- [Fix typo in AxiosInterceptor](https://github.com/multiversx/mx-sdk-dapp/pull/984)
+- [⚠️ Breaking change: Fix typo in AxiosInterceptor](https://github.com/multiversx/mx-sdk-dapp/pull/984)
 
 ## [[v2.24.4]](https://github.com/multiversx/mx-sdk-dapp/pull/983)] - 2023-12-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- [Prevent logout action when not logged in or provider not initialized](https://github.com/multiversx/mx-sdk-dapp/pull/997)
 - [Fix cancel sign message toast](https://github.com/multiversx/mx-sdk-dapp/pull/995)
 - [⚠️ Breaking change: message signing URL to use `addOriginToLocationPath`](https://github.com/multiversx/mx-sdk-dapp/pull/994)
 

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -63,7 +63,6 @@ export async function logout(
     console.error('error fetching logout address', err);
   }
 
-  store.dispatch(logoutAction());
   const url = addOriginToLocationPath(callbackUrl);
   const location = getWindowLocation();
   const callbackPathname = new URL(url).pathname;
@@ -83,6 +82,7 @@ export async function logout(
   }
 
   try {
+    store.dispatch(logoutAction());
     await provider.logout({ callbackUrl: url });
   } catch (err) {
     console.error('error logging out', err);


### PR DESCRIPTION
### Issue
Calling `logout` causes the app the crash if net reloaded at the end.

### Reproduce
Issue exists on version `2.25.2` of sdk-dapp.

### Root cause
Dispatch logout action should also be called only if logged in or if the provider is initialised, simnilar to the provider logout call. Also, it should be called right before the provider logout function call.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
