### PR TITLE
Prevent redirects on logout if the provider is both of wallet type and initialised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.26.4]](https://github.com/multiversx/mx-sdk-dapp/pull/1007)] - 2024-01-04
+- [Prevent redirects on logout if the provider is both of wallet type and initialised](https://github.com/multiversx/mx-sdk-dapp/pull/1006)
+
 ## [[v2.26.3]](https://github.com/multiversx/mx-sdk-dapp/pull/1005)] - 2024-01-03
 - [Fix logout issue with web-wallet](https://github.com/multiversx/mx-sdk-dapp/pull/1004)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.26.3",
+  "version": "2.26.4",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -51,6 +51,7 @@ export async function logout(
   const provider = getAccountProvider();
   const providerType = getProviderType(provider);
   const isWalletProvider = providerType === LoginMethodsEnum.wallet;
+  const isProviderInitialised = provider?.isInitialized?.() != null;
 
   if (shouldAttemptReLogin && provider?.relogin != null) {
     return provider.relogin();
@@ -69,12 +70,15 @@ export async function logout(
 
   // Prevent page redirect if the logout callbackURL is equal to the current URL
   // or if is wallet provider
-  if (matchPath(location.pathname, callbackPathname) || isWalletProvider) {
+  if (
+    matchPath(location.pathname, callbackPathname) ||
+    (isWalletProvider && isProviderInitialised)
+  ) {
     preventRedirects();
   }
 
   // We are already logged out, so we can redirect to the dapp
-  if (!address && provider?.isInitialized?.() == null) {
+  if (!address && !isProviderInitialised) {
     return redirectToCallbackUrl({
       callbackUrl: url,
       onRedirect
@@ -84,7 +88,7 @@ export async function logout(
   try {
     store.dispatch(logoutAction());
 
-    if (providerType === LoginMethodsEnum.wallet) {
+    if (isWalletProvider) {
       // Allow redux store cleanup before redirect to web wallet
       return setTimeout(() => {
         provider.logout({ callbackUrl: url });


### PR DESCRIPTION
### Issue
Logout attempts within sdk-dapp do no redirect to the unlock page of the web wallet.

### Reproduce
Issue exists on version `2.26.3` of sdk-dapp.

### Root cause
If the provider is not initialised, but it is of type wallet then the redirects will fail, becase the `preventRedirects` si set to `true` and the provider itself will no longer make redirects within, as it it not initialised.

### Fix
Set `preventRedirects` to `true` only if the provider is both initialised and of wallet type.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
