### PR TITLE
Extend `checkIsValidSender` with array or string argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [[v2.28.2]](https://github.com/multiversx/mx-sdk-dapp/pull/1030)] - 2024-01-26
+- [Added support for `checkIsValidSender` with array option](https://github.com/multiversx/mx-sdk-dapp/pull/1029)
+
 ## [[v2.28.1]](https://github.com/multiversx/mx-sdk-dapp/pull/1028)] - 2024-01-25
 - [Added support for Web Wallet multisig token login](https://github.com/multiversx/mx-sdk-dapp/pull/1027)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.28.1",
+  "version": "2.28.2",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/hooks/transactions/helpers/checkIsValidSender.ts
+++ b/src/hooks/transactions/helpers/checkIsValidSender.ts
@@ -4,10 +4,18 @@ import { AccountType } from 'types/account.types';
 // is neither the sender or the sender account's active guardian
 export const checkIsValidSender = (
   senderAccount: Partial<AccountType> | null,
-  address: string
+  address: string | string[]
 ) => {
   if (!senderAccount) {
     return true;
+  }
+
+  if (Array.isArray(address)) {
+    return address.some(
+      (addr) =>
+        senderAccount.address === addr ||
+        senderAccount.activeGuardianAddress === addr
+    );
   }
 
   return (


### PR DESCRIPTION
### Feature
Need to check for multiple valid addresses

### Reproduce
Issue exists on version `2.28.1` of sdk-dapp.

### Root cause
Support multisig contract check

### Fix
Extend `checkIsValidSender` with array or string argument

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
