### PR TITLE
Fix walletconnect set account provider

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,16 @@
+name: "CHANGELOG entry secretary"
+on:
+  pull_request:
+    branches: [main, development]
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed setting walletconnectV2 `accountProvider` on init](https://github.com/multiversx/mx-sdk-dapp/pull/1032)
+
 ## [[v2.28.3]](https://github.com/multiversx/mx-sdk-dapp/pull/1032)] - 2024-01-30
 - [Added transaction toast wrapper id](https://github.com/multiversx/mx-sdk-dapp/pull/1031)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- [Fixed setting walletconnectV2 `accountProvider` on init](https://github.com/multiversx/mx-sdk-dapp/pull/1032)
+- [Fixed setting walletconnectV2 `accountProvider` on init](https://github.com/multiversx/mx-sdk-dapp/pull/1033)
 
 ## [[v2.28.3]](https://github.com/multiversx/mx-sdk-dapp/pull/1032)] - 2024-01-30
 - [Added transaction toast wrapper id](https://github.com/multiversx/mx-sdk-dapp/pull/1031)

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -141,6 +141,8 @@ export const useWalletConnectV2Login = ({
         return;
       }
 
+      setAccountProvider(provider);
+
       if (!canLoginRef.current) {
         try {
           await providerRef.current?.logout();
@@ -279,6 +281,8 @@ export const useWalletConnectV2Login = ({
       providerRef.current.init();
 
       setAccountProvider(providerRef.current);
+      console.log('\x1b[42m%s\x1b[0m', 'DID set provider 1');
+
       isInitialisingRef.current = false;
       canLoginRef.current = true;
 
@@ -303,7 +307,6 @@ export const useWalletConnectV2Login = ({
     );
     await newProvider.init();
 
-    setAccountProvider(newProvider);
     providerRef.current = newProvider;
     isInitialisingRef.current = false;
     canLoginRef.current = true;

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -281,7 +281,6 @@ export const useWalletConnectV2Login = ({
       providerRef.current.init();
 
       setAccountProvider(providerRef.current);
-      console.log('\x1b[42m%s\x1b[0m', 'DID set provider 1');
 
       isInitialisingRef.current = false;
       canLoginRef.current = true;


### PR DESCRIPTION
### Issue
Walletconnect conflict with external provider if walletconnect method is not chosen, when all methods are shown including QR code.

### Reproduce
Issue exists on version `2.28.3` of sdk-dapp.

### Root cause
Walletconnect account provider is set when showing QR code. 

### Fix
Delay setting `accountProvider` on `handleLogin`

### Additional changes
Add changelog.yml to workflows

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
