### PR TITLE
Fixed setting `loginToken` in `useLoginService` losing previous state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [[v2.28.4]](https://github.com/multiversx/mx-sdk-dapp/pull/1032)] - 2024-01-31
+
+## [[v2.28.4]](https://github.com/multiversx/mx-sdk-dapp/pull/1035)] - 2024-01-31
+- [Fixed setting `loginToken` in `nativeAuthService` losing previous state](https://github.com/multiversx/mx-sdk-dapp/pull/1034)
 - [Fixed setting walletconnectV2 `accountProvider` on init](https://github.com/multiversx/mx-sdk-dapp/pull/1033)
 
 ## [[v2.28.3]](https://github.com/multiversx/mx-sdk-dapp/pull/1032)] - 2024-01-30

--- a/src/hooks/login/useLoginService.ts
+++ b/src/hooks/login/useLoginService.ts
@@ -43,6 +43,7 @@ export const useLoginService = (config?: OnProviderLoginType['nativeAuth']) => {
     tokenRef.current = loginToken;
     dispatch(
       setTokenLogin({
+        ...tokenLogin,
         loginToken,
         ...(apiAddress ? { nativeAuthConfig: configuration } : {})
       })


### PR DESCRIPTION
### Issue
Setting login token makes reload lose existing information

### Reproduce
Issue exists on version `2.28.3` of sdk-dapp.

### Root cause
Wrong rewrite of loginToken data in redux

### Fix
```
dispatch(
      setTokenLogin({
        ...tokenLogin, // --> ADDED 
        loginToken,
        ...(apiAddress ? { nativeAuthConfig: configuration } : {})
      })
    );

```
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
