### PR TITLE
Fix logout web wallet infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed logout with web wallet infinite loop](https://github.com/multiversx/mx-sdk-dapp/pull/1036)
 
 ## [[v2.28.4]](https://github.com/multiversx/mx-sdk-dapp/pull/1035)] - 2024-02-01
 - [Reverted setting walletconnectV2 `accountProvider` on init](https://github.com/multiversx/mx-sdk-dapp/pull/1036)

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -42,6 +42,8 @@ const broadcastLogoutAcrossTabs = (address: string) => {
   storage.local.removeItem(localStorageKeys.logoutEvent);
 };
 
+const CLEAR_SESSION_TIMEOUT_MS = 500;
+
 export async function logout(
   callbackUrl?: string,
   onRedirect?: (callbackUrl?: string) => void,
@@ -92,9 +94,10 @@ export async function logout(
       // Allow redux store cleanup before redirect to web wallet
       return setTimeout(() => {
         provider.logout({ callbackUrl: url });
-      });
+      }, CLEAR_SESSION_TIMEOUT_MS);
     }
 
+    console.log('\x1b[42m%s\x1b[0m', 'default logout');
     await provider.logout({ callbackUrl: url });
   } catch (err) {
     console.error('error logging out', err);

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -97,7 +97,6 @@ export async function logout(
       }, CLEAR_SESSION_TIMEOUT_MS);
     }
 
-    console.log('\x1b[42m%s\x1b[0m', 'default logout');
     await provider.logout({ callbackUrl: url });
   } catch (err) {
     console.error('error logging out', err);


### PR DESCRIPTION
### Issue
Logging out from a dapp creates infinite loop between dapp logout route and web wallet

### Reproduce
Issue exists on version `2.28.4` of sdk-dapp.

1. set native auth token expirySeconds to 15
2. login with web wallet
3. wait for nativeAuth token to expire
4. sdk-dapp auto-triggers logout and goes to web wallet provider to logout there. CallbackUrl is set to local dapp logout route
5. logout is called again in sdk-dapp and the process repeats

### Root cause
On the second logout sdk dapp store should have been cleared but setTimeout with no arguments is not enough and Chrome redirect prevents full JS execution

### Fix
Delay web wallet navigation by 500ms to allow clearing sdk-dapp store

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
