### PR TITLE
Fix possibly undefined payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed possibly undefined payload on custom toasts](https://github.com/multiversx/mx-sdk-dapp/pull/1036)
+
 ## [[v2.28.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1036)] - 2024-02-01
 - [Fixed logout with web wallet infinite loop](https://github.com/multiversx/mx-sdk-dapp/pull/1036)
 

--- a/src/utils/toasts/customToastsActions.ts
+++ b/src/utils/toasts/customToastsActions.ts
@@ -22,7 +22,7 @@ export const getRegisteredToastCloseHandler = (id: string) =>
 export const addNewCustomToast = (props: CustomToastType) => {
   if (props.component != null) {
     const { component, onClose, ...rest } = props;
-    const { payload } = store.dispatch(
+    const data = store.dispatch(
       addCustomToast({
         ...rest,
         // do not send component to Redux
@@ -31,12 +31,12 @@ export const addNewCustomToast = (props: CustomToastType) => {
       })
     );
 
-    componentsDictionary[payload.toastId] = component;
+    componentsDictionary[data?.payload.toastId] = component;
     if (onClose) {
-      componentsCloseHandlersDictionary[payload.toastId] = onClose;
+      componentsCloseHandlersDictionary[data?.payload.toastId] = onClose;
     }
 
-    return payload;
+    return data?.payload;
   }
   return store.dispatch(addCustomToast(props)).payload;
 };


### PR DESCRIPTION
### Issue
In some cases if there is a mismatch between dapp and sdk-dapp redux store, payload cannot be destructured

### Reproduce
Issue exists on version `2.28.5` of sdk-dapp.

### Root cause

### Fix
Use optional chaining

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
