### PR TITLE
Add option to fetch wallet url on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Added option to access URL search param from application load time in `useParseSignedTransactions`](https://github.com/multiversx/mx-sdk-dapp/pull/1042)
 - [Fixed possibly undefined payload on custom toasts](https://github.com/multiversx/mx-sdk-dapp/pull/1036)
 
 ## [[v2.28.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1036)] - 2024-02-01

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.28.5",
+  "version": "2.28.6",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.28.6-alpha.0",
+  "version": "2.28.6",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.28.6",
+  "version": "2.28.5",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "@multiversx/sdk-wallet": "4.2.0",
     "@multiversx/sdk-wallet-connect-provider": "4.1.0",
     "@multiversx/sdk-web-wallet-cross-window-provider": "0.0.14",
-    "@multiversx/sdk-web-wallet-provider": "3.1.0",
+    "@multiversx/sdk-web-wallet-provider": "3.2.1",
     "@reduxjs/toolkit": "1.8.2",
     "axios": "1.6.5",
     "bignumber.js": "9.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.28.6",
+  "version": "2.28.6-alpha.0",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/hooks/transactions/useParseSignedTransactions.tsx
+++ b/src/hooks/transactions/useParseSignedTransactions.tsx
@@ -20,10 +20,11 @@ import { parseTransactionAfterSigning } from 'utils/transactions/parseTransactio
 import { removeTransactionParamsFromUrl } from 'utils/transactions/removeTransactionParamsFromUrl';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
 
+const { search } = getWindowLocation();
+
 export function useParseSignedTransactions(
   onAbort: (sessionId?: string) => void
 ) {
-  const { search } = getWindowLocation();
   const network = useSelector(networkSelector);
   const dispatch = useDispatch();
 
@@ -36,7 +37,7 @@ export function useParseSignedTransactions(
 
         const signedTransactions = new WalletProvider(
           `${network.walletAddress}${DAPP_INIT_ROUTE}`
-        ).getTransactionsFromWalletUrl();
+        ).getTransactionsFromWalletUrl(search);
 
         if (searchData.status === TransactionBatchStatusesEnum.cancelled) {
           dispatch(

--- a/src/hooks/transactions/useParseSignedTransactions.tsx
+++ b/src/hooks/transactions/useParseSignedTransactions.tsx
@@ -8,7 +8,7 @@ import {
   WALLET_SIGN_SESSION
 } from 'constants/index';
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
-import { networkSelector } from 'reduxStore/selectors';
+import { dappConfigSelector, networkSelector } from 'reduxStore/selectors';
 import {
   moveTransactionsToSignedState,
   setSignTransactionsCancelMessage
@@ -20,13 +20,18 @@ import { parseTransactionAfterSigning } from 'utils/transactions/parseTransactio
 import { removeTransactionParamsFromUrl } from 'utils/transactions/removeTransactionParamsFromUrl';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
 
-const { search } = getWindowLocation();
+const location = getWindowLocation();
 
 export function useParseSignedTransactions(
   onAbort: (sessionId?: string) => void
 ) {
   const network = useSelector(networkSelector);
   const dispatch = useDispatch();
+  const { shouldFetchWalletUrlOnLoad } = useSelector(dappConfigSelector);
+
+  const { search } = shouldFetchWalletUrlOnLoad
+    ? location
+    : getWindowLocation();
 
   useEffect(() => {
     if (search != null) {

--- a/src/types/dappConfig.types.ts
+++ b/src/types/dappConfig.types.ts
@@ -2,5 +2,11 @@ export type DappConfigType = {
   logoutRoute?: string;
   shouldUseWebViewProvider?: boolean;
   cancelTransactionToastDuration?: number;
+  /**
+   * @param {boolean} shouldFetchWalletUrlOnLoad if set,
+   * `useParseSignedTransactions` will read the walletUrl
+   * at application boot instead of hook mount time
+   */
+  shouldFetchWalletUrlOnLoad?: boolean;
   isSSR?: boolean;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,10 +2020,10 @@
     "@types/qs" "6.9.10"
     qs "6.11.2"
 
-"@multiversx/sdk-web-wallet-provider@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-provider/-/sdk-web-wallet-provider-3.1.0.tgz#af6f7e56ff05cd429c677654638dddbcaed1473b"
-  integrity sha512-gIE7AudJl5Ax64AMAD0o6m0cVi+dI5LW2TSM5M9K7zKMWWCflhv27a2A61JkCIQ6CK5OTIkMXaFb61OzUqhplQ==
+"@multiversx/sdk-web-wallet-provider@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-provider/-/sdk-web-wallet-provider-3.2.1.tgz#94ba12140f4f9f35f30b8e13186baa78db4ddaae"
+  integrity sha512-f0CHVsBephFhoQtCAx9y2WhiIZEaNgn0oVa+sZNkgILcXU53Gm8Rj8wMfM0SDimHBYcXCcBDedyLCU3MioOjoQ==
   dependencies:
     qs "6.10.3"
 


### PR DESCRIPTION
### Feature
Allow optionally fetching `walletURL` on application load time 

### Reproduce
Issue exists on version `2.28.6` of sdk-dapp.

### Root cause
If a dApp loads and URL is cleared or dapp navigates to another URL so that useParseSignedTransactions gets loaded later, the search params are cleared and new `WalletProvider().getTransactionsFromWalletUrl` is unable to fetch the transactions

### Fix
Optionally add to `DappConfigType` `shouldFetchWalletUrlOnLoad` option that saves the search param on application load time

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
