### PR TITLE
Fixed wallet connect breaks login with other providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- [Fixed wallet connect breaks login with other providers](https://github.com/multiversx/mx-sdk-dapp/pull/1043)
 - [Fixed possibly undefined payload on custom toasts](https://github.com/multiversx/mx-sdk-dapp/pull/1036)
 
 ## [[v2.28.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1036)] - 2024-02-01

--- a/src/UI/walletConnect/WalletConnectLoginContainer/WalletConnectLoginContainer.tsx
+++ b/src/UI/walletConnect/WalletConnectLoginContainer/WalletConnectLoginContainer.tsx
@@ -1,6 +1,5 @@
 import React, { useRef } from 'react';
 import { withStyles, WithStylesImportType } from 'hocs/withStyles';
-import { useWalletConnectV2Login } from 'hooks/login/useWalletConnectV2Login';
 import { ModalContainer } from 'UI/ModalContainer';
 import { WalletConnectLoginModalPropsType } from './types';
 import { WalletConnectLoginContent } from './WalletConnectLoginContent';
@@ -9,34 +8,18 @@ const WalletConnectLoginContainerComponent = (
   props: WalletConnectLoginModalPropsType & WithStylesImportType
 ) => {
   const {
-    callbackRoute,
     className,
-    logoutRoute,
-    nativeAuth,
     onClose,
-    onLoginRedirect,
     showLoginContent,
     showLoginModal,
-    token,
     wrapContentInsideModal,
     styles,
-    customRequestMethods
+    canLoginRef: parentCanLoginRef
   } = props;
 
-  const canLoginRef = useRef<boolean>(true);
-
-  const [, , { cancelLogin }] = useWalletConnectV2Login({
-    callbackRoute,
-    token,
-    nativeAuth,
-    onLoginRedirect,
-    logoutRoute,
-    canLoginRef,
-    customRequestMethods
-  });
+  const canLoginRef = parentCanLoginRef ?? useRef<boolean>(true);
 
   const onCloseModal = async () => {
-    await cancelLogin();
     onClose?.();
   };
 

--- a/src/UI/walletConnect/WalletConnectLoginContainer/WalletConnectLoginContent/WalletConnectLoginContent.tsx
+++ b/src/UI/walletConnect/WalletConnectLoginContainer/WalletConnectLoginContent/WalletConnectLoginContent.tsx
@@ -98,8 +98,12 @@ const WalletConnectLoginContentComponent = ({
   }, [walletConnectUriV2]);
 
   useEffect(() => {
+    if (canLoginRef?.current === false) {
+      return;
+    }
+
     initLoginWithWalletConnectV2();
-  }, []);
+  }, [canLoginRef?.current]);
 
   const authorizationInfo = showScamPhishingAlert
     ? getAuthorizationInfo(token, containerScamPhishingAlertClassName)

--- a/src/hooks/login/useExtensionLogin.ts
+++ b/src/hooks/login/useExtensionLogin.ts
@@ -88,6 +88,7 @@ export const useExtensionLogin = ({
       if (!address) {
         setIsLoading(false);
         console.warn('Login cancelled.');
+        setError('Login cancelled');
         return;
       }
 
@@ -108,7 +109,7 @@ export const useExtensionLogin = ({
         options: { signature, address }
       });
     } catch (error) {
-      console.error('error loging in', error);
+      console.error('error logging in', error);
       // TODO: can be any or typed error
       setError('error logging in' + (error as any).message);
     } finally {


### PR DESCRIPTION
### Issue
Cannot login with wallet connect and other providers, if the `WalletConnectLoginContainer` is used as standalone component without the modal in the login/unlock page.

### Reproduce
Issue exists on version `2.28.5` of sdk-dapp.

### Root cause
Wallet connect is initialising and logging in automatically on component init if used as standalone component, because it is no longer destroyed like the modal is.

### Fix
Prevent auto-login on component init.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
