### PR TITLE
Add support for nativeAuth impersonate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Added support for nativeAuth impersonat](https://github.com/multiversx/mx-sdk-dapp/pull/1049)
 
 ## [[v2.28.7]](https://github.com/multiversx/mx-sdk-dapp/pull/1048)] - 2024-02-13
 - [Updated AddressRow data-testids](https://github.com/multiversx/mx-sdk-dapp/pull/1047)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.28.7-alpha.1",
+  "version": "2.28.7-alpha.2",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "@multiversx/sdk-opera-provider": "1.0.0-alpha.1",
     "@multiversx/sdk-wallet": "4.2.0",
     "@multiversx/sdk-wallet-connect-provider": "4.1.0",
-    "@multiversx/sdk-web-wallet-cross-window-provider": "0.0.21",
+    "@multiversx/sdk-web-wallet-cross-window-provider": "0.0.22",
     "@multiversx/sdk-web-wallet-provider": "3.2.1",
     "@reduxjs/toolkit": "1.8.2",
     "axios": "1.6.5",

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -47,7 +47,7 @@ import {
   getOperaProvider,
   getCrossWindowProvider,
   getExtensionProvider,
-  processMultisigAccount
+  processModifiedAccount
 } from './helpers';
 import { useSetLedgerProvider } from './hooks';
 
@@ -167,12 +167,13 @@ export function ProviderInitializer() {
       const address = await getAddress();
       const {
         clearNavigationHistory,
-        remainingParams: { signature, multisig }
+        remainingParams: { signature, multisig, impersonate }
       } = parseNavigationParams([
         'signature',
         'loginToken',
         'address',
-        'multisig'
+        'multisig',
+        'impersonate'
       ]);
 
       if (!address) {
@@ -182,9 +183,12 @@ export function ProviderInitializer() {
         return clearNavigationHistory();
       }
 
-      const account = await processMultisigAccount({
+      const account = await processModifiedAccount({
         loginToken: tokenLogin?.loginToken,
-        multisig,
+        extraInfoData: {
+          multisig,
+          impersonate
+        },
         address,
         signature,
         loginService

--- a/src/components/ProviderInitializer/helpers/getModifiedLoginToken.ts
+++ b/src/components/ProviderInitializer/helpers/getModifiedLoginToken.ts
@@ -4,14 +4,17 @@ import { nativeAuth } from 'services/nativeAuth/nativeAuth';
 
 export interface GetMultiSigLoginTokenType {
   loginToken?: string;
-  multisig?: string;
+  extraInfoData: {
+    multisig?: string;
+    impersonate?: string;
+  };
 }
 
-export const getMultiSigLoginToken = async ({
+export const getModifiedLoginToken = async ({
   loginToken,
-  multisig
+  extraInfoData
 }: GetMultiSigLoginTokenType) => {
-  if (loginToken == null || multisig == null) {
+  if (loginToken == null || Object.keys(extraInfoData).length === 0) {
     return null;
   }
 
@@ -29,7 +32,7 @@ export const getMultiSigLoginToken = async ({
   };
 
   const tokenLogin = await nativeAuth({
-    extraInfo: { ...rest, multisig },
+    extraInfo: { ...rest, ...extraInfoData },
     expirySeconds: data?.ttl,
     origin: data?.origin
   }).initialize({

--- a/src/components/ProviderInitializer/helpers/index.ts
+++ b/src/components/ProviderInitializer/helpers/index.ts
@@ -1,5 +1,5 @@
 export * from './getOperaProvider';
 export * from './getExtensionProvider';
 export * from './getCrossWindowProvider';
-export * from './getMultiSigLoginToken';
 export * from './processMultisigAccount';
+export * from './getModifiedLoginToken';

--- a/src/components/ProviderInitializer/helpers/processMultisigAccount.ts
+++ b/src/components/ProviderInitializer/helpers/processMultisigAccount.ts
@@ -1,9 +1,10 @@
 import { getAccount } from 'utils/account/getAccount';
-import { getMultiSigLoginToken } from './getMultiSigLoginToken';
+import {
+  getModifiedLoginToken,
+  GetMultiSigLoginTokenType
+} from './getModifiedLoginToken';
 
-interface SetMultisigLoginToken<T> {
-  loginToken?: string;
-  multisig?: string;
+interface SetMultisigLoginToken<T> extends GetMultiSigLoginTokenType {
   signature?: string;
   address: string;
   loginService: T;
@@ -22,17 +23,20 @@ export const processMultisigAccount = async <
   }
 >({
   loginToken: token,
-  multisig,
+  extraInfoData,
   address,
   signature,
   loginService
 }: SetMultisigLoginToken<T>) => {
-  const loginToken = await getMultiSigLoginToken({
+  const loginToken = await getModifiedLoginToken({
     loginToken: token,
-    multisig
+    extraInfoData
   });
 
-  const accountAddress = loginToken != null ? multisig : address;
+  let tokenAddress =
+    extraInfoData.multisig || extraInfoData.impersonate || address;
+
+  const accountAddress = loginToken != null ? tokenAddress : address;
 
   if (loginToken != null) {
     loginService.setLoginToken(loginToken);

--- a/src/components/ProviderInitializer/helpers/processMultisigAccount.ts
+++ b/src/components/ProviderInitializer/helpers/processMultisigAccount.ts
@@ -10,7 +10,7 @@ interface SetMultisigLoginToken<T> extends GetMultiSigLoginTokenType {
   loginService: T;
 }
 
-export const processMultisigAccount = async <
+export const processModifiedAccount = async <
   T extends {
     setLoginToken: (loginToken: string) => void;
     setTokenLoginInfo: ({

--- a/src/components/ProviderInitializer/helpers/tests/getModifiedLoginToken.test.ts
+++ b/src/components/ProviderInitializer/helpers/tests/getModifiedLoginToken.test.ts
@@ -1,19 +1,25 @@
-import { getMultiSigLoginToken } from '../getMultiSigLoginToken';
+import { getModifiedLoginToken } from '../getModifiedLoginToken';
 
 describe('getMultiSigLoginToken', () => {
   test('returns null if loginToken or multisig is null', async () => {
-    const result = await getMultiSigLoginToken({
+    const result = await getModifiedLoginToken({
       loginToken: undefined,
-      multisig: 'erd1qqqqqqqqqqqqqpgq944h7h6mckw6q0d3g223cjz4ytvken86u00sz7carw'
+      extraInfoData: {
+        multisig:
+          'erd1qqqqqqqqqqqqqpgq944h7h6mckw6q0d3g223cjz4ytvken86u00sz7carw'
+      }
     });
 
     expect(result).toBeNull();
   });
 
   test('returns null if data or timestamp is missing', async () => {
-    const result = await getMultiSigLoginToken({
+    const result = await getModifiedLoginToken({
       loginToken: 'invalidLoginToken',
-      multisig: 'erd1qqqqqqqqqqqqqpgq944h7h6mckw6q0d3g223cjz4ytvken86u00sz7carw'
+      extraInfoData: {
+        multisig:
+          'erd1qqqqqqqqqqqqqpgq944h7h6mckw6q0d3g223cjz4ytvken86u00sz7carw'
+      }
     });
 
     expect(result).toBeNull();
@@ -23,10 +29,13 @@ describe('getMultiSigLoginToken', () => {
     const validInput = {
       loginToken:
         'aHR0cHM6Ly9kZXZuZXQueGV4Y2hhbmdlLmNvbQ.d9ee880c609d5fe482a675826eb7e74f707c882e796ec191913a6c18d762685d.86400.eyJ0aW1lc3RhbXAiOjE3MDYxODAwMjd9',
-      multisig: 'erd1qqqqqqqqqqqqqpgq944h7h6mckw6q0d3g223cjz4ytvken86u00sz7carw'
+      extraInfoData: {
+        multisig:
+          'erd1qqqqqqqqqqqqqpgq944h7h6mckw6q0d3g223cjz4ytvken86u00sz7carw'
+      }
     };
 
-    const result = await getMultiSigLoginToken(validInput);
+    const result = await getModifiedLoginToken(validInput);
 
     const expectedTokenLogin =
       'aHR0cHM6Ly9kZXZuZXQueGV4Y2hhbmdlLmNvbQ.d9ee880c609d5fe482a675826eb7e74f707c882e796ec191913a6c18d762685d.86400.eyJtdWx0aXNpZyI6ImVyZDFxcXFxcXFxcXFxcXFxcGdxOTQ0aDdoNm1ja3c2cTBkM2cyMjNjano0eXR2a2VuODZ1MDBzejdjYXJ3IiwidGltZXN0YW1wIjoxNzA2MTgwMDI3fQ';

--- a/src/hooks/login/useCrossWindowLogin.ts
+++ b/src/hooks/login/useCrossWindowLogin.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { CrossWindowProvider } from '@multiversx/sdk-web-wallet-cross-window-provider';
-import { processMultisigAccount } from 'components/ProviderInitializer/helpers/processMultisigAccount';
+import { processModifiedAccount } from 'components/ProviderInitializer/helpers/processMultisigAccount';
 import { SECOND_LOGIN_ATTEMPT_ERROR } from 'constants/errorsMessages';
 import { setAccountProvider } from 'providers/accountProvider';
 import { loginAction } from 'reduxStore/commonActions';
@@ -96,7 +96,7 @@ export const useCrossWindowLogin = ({
         return;
       }
 
-      const account = await processMultisigAccount({
+      const account = await processModifiedAccount({
         loginToken: token,
         multisig,
         address,

--- a/src/hooks/login/useCrossWindowLogin.ts
+++ b/src/hooks/login/useCrossWindowLogin.ts
@@ -84,9 +84,8 @@ export const useCrossWindowLogin = ({
         ...(token && { token })
       };
 
-      const { signature, address, multisig } = await provider.login(
-        providerLoginData
-      );
+      const { signature, address, multisig, impersonate } =
+        await provider.login(providerLoginData);
 
       setAccountProvider(provider);
 
@@ -98,7 +97,7 @@ export const useCrossWindowLogin = ({
 
       const account = await processModifiedAccount({
         loginToken: token,
-        multisig,
+        extraInfoData: { multisig, impersonate },
         address,
         signature,
         loginService

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,10 +2020,10 @@
     tweetnacl "1.0.3"
     uuid "8.3.2"
 
-"@multiversx/sdk-web-wallet-cross-window-provider@0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-cross-window-provider/-/sdk-web-wallet-cross-window-provider-0.0.21.tgz#f9d1dafea40c94c3db7aac8cb4c5b6b86f82efb4"
-  integrity sha512-4nmueZwk/WRwvXW59ygUOHlah/xGZpb5LWdssHf8LUO3dG10zZptZmutFqgyeU65ayD/jnWK+HRxkKmMN5uqvg==
+"@multiversx/sdk-web-wallet-cross-window-provider@0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-cross-window-provider/-/sdk-web-wallet-cross-window-provider-0.0.22.tgz#cea751c6b1846fbfbc7e17eba0031a56979b1c19"
+  integrity sha512-cD9ePvb+Kju4lYh7QCn7vrINEinDTRZAQhIeNe3Dt3HTd07Af48AUU01EjdEKnivROiKnXj5DKKmR8GZlSH7Tg==
   dependencies:
     "@multiversx/sdk-core" "12.18.0"
     "@types/jest" "^29.5.11"


### PR DESCRIPTION
### Feature
Add support for impersonate in nativeAuth token

### Reproduce
Issue exists on version `2.28.7` of sdk-dapp.

### Root cause
Allow some addresses to impersonate trough nativeAuth token by integrating `impersonate` key in `extraInfo`

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
