### PR TITLE
Fix wallet connect chainID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.28.7-alpha.13",
+  "version": "2.28.7-alpha.14",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,3 +25,4 @@ export * from './validation';
 export * from './websocket';
 export * from './window';
 export * from './getHasNativeAuth';
+export * from './waitForChainID';

--- a/src/utils/waitForChainID.ts
+++ b/src/utils/waitForChainID.ts
@@ -1,0 +1,33 @@
+import { getEnvironmentForChainId } from 'apiCalls';
+import { chainIDSelector } from 'reduxStore/selectors';
+import { store } from 'reduxStore/store';
+
+export const waitForChainID = ({
+  maxRetries
+}: {
+  maxRetries: number;
+}): Promise<string | null> =>
+  new Promise((resolve, reject) => {
+    let retries = 0;
+
+    // Function to periodically check the value of chainID
+    const checkChainID = () => {
+      const chainID = chainIDSelector(store.getState());
+      const isValidEnvironment = getEnvironmentForChainId(chainID);
+
+      if (Boolean(isValidEnvironment)) {
+        resolve(chainID);
+        return;
+      }
+
+      if (retries < maxRetries) {
+        retries++;
+        setTimeout(checkChainID, 1000);
+        return;
+      }
+
+      reject(null);
+    };
+
+    checkChainID();
+  });


### PR DESCRIPTION
### Issue
WalletConnect instance could be created with invalid `chainID` which will make all transactions not being able to be processed.

### Reproduce
Issue exists on version `2.28.7-alpha.13` of sdk-dapp.

### Root cause
API request of `chainID` might be longer than expected and WalletConnect will initialize with invalid `chainID`

### Fix
Add a promise retry mechanism in `useWalletConnectV2Login` in order to wait until the `chainID` is valid.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
