### PR TITLE
Fix ledger guardian signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fixed signing multiple transactions with guarded ledger](https://github.com/multiversx/mx-sdk-dapp/pull/1059)
 - [Added getHasNativeAuth in order to see if nativeAuth has been configured on development mode](https://github.com/multiversx/mx-sdk-dapp/pull/1051)
 - [Added support for nativeAuth impersonat](https://github.com/multiversx/mx-sdk-dapp/pull/1049)
 - [Updated WalletConnectV2 account provider to be updated on new or existing session](https://github.com/multiversx/mx-sdk-dapp/pull/1050)

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/SignStep.tsx
@@ -87,8 +87,8 @@ const SignStepComponent = (props: SignStepType & WithStylesImportType) => {
 
   const signLastTransaction = isLastTransaction && !waitingForDevice;
 
-  const onSubmit = () => {
-    onSignTransaction();
+  const onSubmit = async () => {
+    await onSignTransaction();
     if (signLastTransaction && GuardianScreen) {
       return setShowGuardianScreen(true);
     }

--- a/src/hooks/transactions/helpers/getAreAllTransactionsSignedByGuardian.ts
+++ b/src/hooks/transactions/helpers/getAreAllTransactionsSignedByGuardian.ts
@@ -7,10 +7,15 @@ export const getAreAllTransactionsSignedByGuardian = ({
   transactions: Transaction[];
   isGuarded?: boolean;
 }) => {
-  const allSignedByGuardian = isGuarded
-    ? transactions.every((tx) =>
-        Boolean(tx.getGuardianSignature().toString('hex'))
-      )
-    : true;
-  return allSignedByGuardian;
+  if (!isGuarded) {
+    return true;
+  }
+
+  if (transactions.length === 0) {
+    return false;
+  }
+
+  return transactions.every((tx) =>
+    Boolean(tx.getGuardianSignature().toString('hex'))
+  );
 };

--- a/src/hooks/transactions/useSignMultipleTransactions.tsx
+++ b/src/hooks/transactions/useSignMultipleTransactions.tsx
@@ -157,6 +157,19 @@ export function useSignMultipleTransactions({
   }
 
   async function sign() {
+    const existingSignedTransactions = Object.values(signedTransactions ?? {});
+
+    const alreadySignedByGuardian = getAreAllTransactionsSignedByGuardian({
+      isGuarded,
+      transactions: existingSignedTransactions
+    });
+
+    if (alreadySignedByGuardian) {
+      onTransactionsSignSuccess(existingSignedTransactions);
+      reset();
+      return;
+    }
+
     if (currentTransaction == null) {
       return;
     }
@@ -174,7 +187,8 @@ export function useSignMultipleTransactions({
         : null;
 
       reset();
-      return onTransactionsSignError(errorMessage ?? message);
+      onTransactionsSignError(errorMessage ?? message);
+      return;
     }
 
     if (!signedTx) {
@@ -212,7 +226,7 @@ export function useSignMultipleTransactions({
     reset();
   }
 
-  function signTx() {
+  async function signTx() {
     try {
       if (currentTransaction == null) {
         return;
@@ -224,10 +238,10 @@ export function useSignMultipleTransactions({
         return;
       }
 
-      sign();
+      await sign();
     } catch {
       // the only way to check if tx has signature is with try catch
-      sign();
+      await sign();
     }
   }
 
@@ -249,12 +263,12 @@ export function useSignMultipleTransactions({
       )
   );
 
-  function handleSignTransaction() {
+  async function handleSignTransaction() {
     if (shouldContinueWithoutSigning) {
       setCurrentStep((exising) => exising + 1);
-    } else {
-      signTx();
+      return;
     }
+    await signTx();
   }
 
   function onNext() {

--- a/src/hooks/transactions/useSignTransactionsWithDevice.tsx
+++ b/src/hooks/transactions/useSignTransactionsWithDevice.tsx
@@ -37,7 +37,7 @@ export interface UseSignTransactionsWithDevicePropsType {
 
 export interface UseSignTransactionsWithDeviceReturnType {
   allTransactions: MultiSignTransactionType[];
-  onSignTransaction: () => void;
+  onSignTransaction: () => Promise<void>;
   onNext: () => void;
   onPrev: () => void;
   onAbort: () => void;
@@ -145,7 +145,9 @@ export function useSignTransactionsWithDevice(
     clearTransactionsToSignWithWarning(sessionId);
   }
 
-  async function handleSignTransaction(transaction: Nullable<Transaction>) {
+  async function handleSignTransaction(
+    transaction: Nullable<Transaction>
+  ): Promise<Nullable<Transaction | undefined>> {
     const connectedProvider =
       providerType !== LoginMethodsEnum.ledger
         ? provider

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -191,7 +191,7 @@ export type DeviceSignedTransactions = Record<number, Transaction>;
 
 export interface GuardianScreenType extends WithClassnameType {
   address: string;
-  onSignTransaction: () => void;
+  onSignTransaction: () => Promise<void>;
   onPrev: () => void;
   title?: ReactNode;
   signStepInnerClasses?: SignStepInnerClassesType;


### PR DESCRIPTION
### Issue
Unable to sign multiple guarded ledger transactions

### Reproduce
Issue exists on version `2.28.7-alpha.21` of sdk-dapp.

### Root cause
Ledger flow was reset and sigining was called again at the end

### Fix
Change `useSignMultipleTransactions` to make `sign` return a promise and wait for signing & if all have been signed by guardian exit the flow with `onTransactionsSignSuccess`

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
