### PR TITLE
Fixed base64 utils encoding check and conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[v2.28.8]](https://github.com/multiversx/mx-sdk-dapp/pull/1050)] - 2024-03-07
-- [Fixed base64 utils conversion](https://github.com/multiversx/mx-sdk-dapp/pull/1049)
+## [[v2.28.8]](https://github.com/multiversx/mx-sdk-dapp/pull/1062)] - 2024-03-07
+- [Fixed base64 utils conversion](https://github.com/multiversx/mx-sdk-dapp/pull/1061)
 
 ## [[v2.28.7]](https://github.com/multiversx/mx-sdk-dapp/pull/1048)] - 2024-02-13
 - [Updated AddressRow data-testids](https://github.com/multiversx/mx-sdk-dapp/pull/1047)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.28.8]](https://github.com/multiversx/mx-sdk-dapp/pull/1050)] - 2024-03-07
+- [Fixed base64 utils conversion](https://github.com/multiversx/mx-sdk-dapp/pull/1049)
+
 ## [[v2.28.7]](https://github.com/multiversx/mx-sdk-dapp/pull/1048)] - 2024-02-13
 - [Updated AddressRow data-testids](https://github.com/multiversx/mx-sdk-dapp/pull/1047)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.28.7",
+  "version": "2.28.8",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/utils/decoders/base64Utils.ts
+++ b/src/utils/decoders/base64Utils.ts
@@ -26,8 +26,10 @@ export function isStringBase64(str: string) {
     const bufferFromEncoded = Buffer.from(bufferFromDecoded).toString('base64');
 
     // If the result is equal to the initial string
-    const isEqualToInitialString =
-      str === btoaEncoded && str === bufferFromEncoded;
+    const isBtoaEqual = str === btoaEncoded || btoaEncoded.startsWith(str);
+    const isBufferFromBase64Equal =
+      str === bufferFromEncoded || bufferFromEncoded.startsWith(str);
+    const isEqualToInitialString = isBtoaEqual && isBufferFromBase64Equal;
 
     if (isEqualToInitialString) {
       // it is a regular base64 string

--- a/src/utils/decoders/base64Utils.ts
+++ b/src/utils/decoders/base64Utils.ts
@@ -12,8 +12,7 @@
  *
  * Solution:
  * - if any conversion fails (atob(), btoa() or Buffer.from()), it is definitely not an encoded string
- * - if atob() conversion is equal to Buffer.from() conversion
- * or the string is equal to btoa() conversion of atob(), it is a regular base64 string
+ * - if the string is equal
  *
  * @see The tests for this function are in src/utils/decoders/tests/base64Utils.test.ts
  * @param str
@@ -30,10 +29,7 @@ export function isStringBase64(str: string) {
     const isEqualToInitialString =
       str === btoaEncoded && str === bufferFromEncoded;
 
-    // or the atob() conversion is equal to the Buffer.from('base64')
-    const isAtobEqualToBufferFrom = atobDecoded === bufferFromDecoded;
-
-    if (isEqualToInitialString || isAtobEqualToBufferFrom) {
+    if (isEqualToInitialString) {
       // it is a regular base64 string
       return true;
     }

--- a/src/utils/decoders/tests/base64Utils.test.ts
+++ b/src/utils/decoders/tests/base64Utils.test.ts
@@ -64,4 +64,9 @@ describe('isStringBase64', () => {
     );
     expect(result).toStrictEqual(false);
   });
+
+  it('should return false for atob equal to base64 conversion', async () => {
+    const result = isStringBase64('fd');
+    expect(result).toStrictEqual(false);
+  });
 });


### PR DESCRIPTION
### Issue
Transaction data string `fd` is treated as base64 encoded string and transformed into `}`

### Reproduce
Issue exists on version `2.28.7` of sdk-dapp.

### Root cause
`atob()` and `Buffer.from()` of `fd` are equal, so, the utility function `isStringBase64()` returns `true` which forces an additional encoding of the transaction data field.

### Fix
Remove the check for the equality of `atob()` and `Buffer.from()` as a condition for base64 encoding.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
