### PR TITLE
Fix experimental webview provider initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix experimental webview provider initialization](https://github.com/multiversx/mx-sdk-dapp/pull/1070)
+
 ## [[v2.29.0-beta.0]](https://github.com/multiversx/mx-sdk-dapp/pull/1069)] - 2024-03-11
 - [Fixed types and file names](https://github.com/multiversx/mx-sdk-dapp/pull/1068)
 - [Add support for the new cross window functionality in web wallet](https://github.com/multiversx/mx-sdk-dapp/pull/1067)

--- a/src/providers/accountProvider.ts
+++ b/src/providers/accountProvider.ts
@@ -28,7 +28,6 @@ export function setAccountProvider<TProvider extends ProvidersType>(
 
 export function setExternalProvider(provider: IDappProvider) {
   externalProvider = provider;
-  externalProvider.init?.();
 }
 
 export function setExternalProviderAsAccountProvider() {

--- a/src/providers/accountProvider.ts
+++ b/src/providers/accountProvider.ts
@@ -28,6 +28,7 @@ export function setAccountProvider<TProvider extends ProvidersType>(
 
 export function setExternalProvider(provider: IDappProvider) {
   externalProvider = provider;
+  externalProvider.init?.();
 }
 
 export function setExternalProviderAsAccountProvider() {

--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -63,6 +63,11 @@ export class ExperimentalWebviewProvider implements IDappProvider {
   };
 
   init = async () => {
+    this.sendPostMessage({
+      type: CrossWindowProviderRequestEnums.finalizeHandshakeRequest,
+      payload: undefined
+    });
+
     return true;
   };
 
@@ -151,7 +156,13 @@ export class ExperimentalWebviewProvider implements IDappProvider {
     return message;
   }
 
-  async waitingForResponse<T extends CrossWindowProviderResponseEnums>(
+  isInitialized = () => true;
+
+  isConnected = async () => true;
+
+  getAddress = notInitializedError('getAddress');
+
+  private async waitingForResponse<T extends CrossWindowProviderResponseEnums>(
     action: T
   ): Promise<{
     type: T;
@@ -165,7 +176,7 @@ export class ExperimentalWebviewProvider implements IDappProvider {
     });
   }
 
-  sendPostMessage = async <T extends CrossWindowProviderRequestEnums>(
+  private sendPostMessage = async <T extends CrossWindowProviderRequestEnums>(
     message: PostMessageParamsType<T>
   ): Promise<PostMessageReturnType<T>> => {
     const safeWindow = typeof window !== 'undefined' ? window : ({} as any);
@@ -186,8 +197,4 @@ export class ExperimentalWebviewProvider implements IDappProvider {
 
     return await this.waitingForResponse(responseTypeMap[message.type]);
   };
-
-  isInitialized = () => true;
-  isConnected = async () => true;
-  getAddress = notInitializedError('getAddress');
 }

--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -63,6 +63,11 @@ export class ExperimentalWebviewProvider implements IDappProvider {
   };
 
   init = async () => {
+    this.sendPostMessage({
+      type: CrossWindowProviderRequestEnums.finalizeHandshakeRequest,
+      payload: undefined
+    });
+
     return true;
   };
 

--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -63,11 +63,6 @@ export class ExperimentalWebviewProvider implements IDappProvider {
   };
 
   init = async () => {
-    this.sendPostMessage({
-      type: CrossWindowProviderRequestEnums.finalizeHandshakeRequest,
-      payload: undefined
-    });
-
     return true;
   };
 

--- a/src/wrappers/DappProvider/DappProvider.tsx
+++ b/src/wrappers/DappProvider/DappProvider.tsx
@@ -23,8 +23,8 @@ export { DappConfigType };
 const setWebviewProvider = () => {
   if (getWebviewPlatform() === PlatformsEnum.webWallet) {
     const providerInstance = ExperimentalWebviewProvider.getInstance();
-    setExternalProvider(providerInstance);
     providerInstance.init?.();
+    setExternalProvider(providerInstance);
   } else {
     setExternalProvider(webviewProvider);
   }

--- a/src/wrappers/DappProvider/DappProvider.tsx
+++ b/src/wrappers/DappProvider/DappProvider.tsx
@@ -22,7 +22,9 @@ export { DappConfigType };
 
 const setWebviewProvider = () => {
   if (getWebviewPlatform() === PlatformsEnum.webWallet) {
-    setExternalProvider(ExperimentalWebviewProvider.getInstance());
+    const providerInstance = ExperimentalWebviewProvider.getInstance();
+    setExternalProvider(providerInstance);
+    providerInstance.init?.();
   } else {
     setExternalProvider(webviewProvider);
   }


### PR DESCRIPTION
### Issue
The experimental webview provider doesn't notify the parent when is loaded.
### Reproduce
Issue exists on version `2.29.0-beta.0` of sdk-dapp.

### Root cause
Wrong implementation of the init() function

### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
