### PR TITLE
Fixed different address than account address in account info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- [Fixed different address than account address in account info](https://github.com/multiversx/mx-sdk-dapp/pull/1076)
+
 ## [[v2.29.0-beta.3]](https://github.com/multiversx/mx-sdk-dapp/pull/1073)] - 2024-03-12
 - [Fixed WebWallet logout not working](https://github.com/multiversx/mx-sdk-dapp/pull/1074)
 

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -33,7 +33,8 @@ import {
   setWalletLogin,
   setChainID,
   setTokenLogin,
-  setIsWalletConnectV2Initialized
+  setIsWalletConnectV2Initialized,
+  setAddress
 } from 'reduxStore/slices';
 import { LoginMethodsEnum } from 'types/enums.types';
 import {
@@ -149,12 +150,16 @@ export function ProviderInitializer() {
               nonce: account.nonce.valueOf()
             })
           );
+        } else if (!isLoggedIn) {
+          // Clear the address and publicKey if account is not found
+          dispatch(setAddress(''));
         }
       } catch (e) {
         dispatch(setAccountLoadingError('Failed getting account'));
         console.error('Failed getting account ', e);
       }
     }
+
     dispatch(setIsAccountLoading(false));
   }
 

--- a/src/reduxStore/selectors/accountInfoSelectors.ts
+++ b/src/reduxStore/selectors/accountInfoSelectors.ts
@@ -23,7 +23,8 @@ export const accountInfoSelector = createDeepEqualSelector(
   (state, account) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { accounts, ...info } = state;
-    return { ...info, account };
+
+    return { ...info, address: account.address, account };
   }
 );
 

--- a/src/reduxStore/slices/accountInfoSlice.ts
+++ b/src/reduxStore/slices/accountInfoSlice.ts
@@ -76,7 +76,7 @@ export const accountInfoSlice = createSlice({
     ) => {
       const address = action.payload;
       state.address = address;
-      state.publicKey = new Address(address).hex();
+      state.publicKey = address ? new Address(address).hex() : '';
     },
     setAccount: (
       state: AccountInfoSliceType,


### PR DESCRIPTION
### Issue
The `address` from `useGetAccountInfo` hook is different than the `address` from `useGetAccount` hook.

### Reproduce
Issue exists on version `2.29.0-beta.3` of sdk-dapp.

### Root cause
In case the getAccount fails, the `address` from `loginInfoSlice` is not reset.

### Fix
Return the account address in the `accountInfoSelector` as the main address and clear the `address` and `publicKey` from `loginInfloSlice` in case the `getAccount` fails.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
