### PR TITLE
Fix web wallet URL construction on logout action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- [Fix web wallet URL construction on logout action](https://github.com/multiversx/mx-sdk-dapp/pull/1079)
+
 ## [[v2.29.0-beta.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1078)] - 2024-03-14
 - [Added 2FA signing cancel action](https://github.com/multiversx/mx-sdk-dapp/pull/1077)
 

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -68,7 +68,7 @@ export async function logout(
 
   const url = addOriginToLocationPath(callbackUrl);
   const location = getWindowLocation();
-  const callbackPathname = new URL(url).pathname;
+  const callbackPathname = new URL(decodeURIComponent(url)).pathname;
 
   // Prevent page redirect if the logout callbackURL is equal to the current URL
   // or if is wallet provider


### PR DESCRIPTION
### Issue
"Failed to construct 'URL': Invalid URL"
### Reproduce
Issue exists on version `2.29.0-beta.5` of sdk-dapp.

### Root cause
The URL coming from the wallet should be decoded.
### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
