### PR TITLE
ExperimentalWebviewProvider: "Cancel response" handling for the signTransactions and signMessage actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [ExperimentalWebviewProvider: Cancel response handling for the signTransactions and signMessage actions](https://github.com/multiversx/mx-sdk-dapp/pull/1086)
+- [ExperimentalWebviewProvider: "Cancel response" handling for the signTransactions and signMessage actions](https://github.com/multiversx/mx-sdk-dapp/pull/1086)
 
 ## [[v2.29.0-beta.9]](https://github.com/multiversx/mx-sdk-dapp/pull/1085)] - 2024-03-19
 - [Reverted change](https://github.com/multiversx/mx-sdk-dapp/pull/1085)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [ExperimentalWebviewProvider: Cancel response handling for the signTransactions and signMessage actions](https://github.com/multiversx/mx-sdk-dapp/pull/1086)
+
 ## [[v2.29.0-beta.9]](https://github.com/multiversx/mx-sdk-dapp/pull/1085)] - 2024-03-19
 - [Reverted change](https://github.com/multiversx/mx-sdk-dapp/pull/1085)
 

--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -1,4 +1,4 @@
-import { Transaction, SignableMessage } from '@multiversx/sdk-core';
+import { SignableMessage, Transaction } from '@multiversx/sdk-core';
 import { responseTypeMap } from '@multiversx/sdk-web-wallet-cross-window-provider/out/constants';
 import {
   CrossWindowProviderRequestEnums,
@@ -125,6 +125,11 @@ export class ExperimentalWebviewProvider implements IDappProvider {
       return null;
     }
 
+    if (response.type == CrossWindowProviderResponseEnums.cancelResponse) {
+      console.error('Cancelled the transactions signing action');
+      return null;
+    }
+
     return signedTransactions.map((tx) => Transaction.fromPlainObject(tx));
   };
 
@@ -143,6 +148,11 @@ export class ExperimentalWebviewProvider implements IDappProvider {
 
     if (error || !data) {
       console.error('Unable to sign message');
+      return null;
+    }
+
+    if (response.type == CrossWindowProviderResponseEnums.cancelResponse) {
+      console.error('Cancelled the message signing action');
       return null;
     }
 

--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -126,7 +126,7 @@ export class ExperimentalWebviewProvider implements IDappProvider {
     }
 
     if (response.type == CrossWindowProviderResponseEnums.cancelResponse) {
-      console.error('Cancelled the transactions signing action');
+      console.warn('Cancelled the transactions signing action');
       return null;
     }
 
@@ -152,7 +152,7 @@ export class ExperimentalWebviewProvider implements IDappProvider {
     }
 
     if (response.type == CrossWindowProviderResponseEnums.cancelResponse) {
-      console.error('Cancelled the message signing action');
+      console.warn('Cancelled the message signing action');
       return null;
     }
 


### PR DESCRIPTION
### Issue
Incorrect response handling for signTransactions and signMessage actions
### Reproduce
Issue exists on version `2.29.0-beta.9` of sdk-dapp.

### Root cause

### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
