### PR TITLE
Add protobufjs as dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Add protobufjs as dependency](https://github.com/multiversx/mx-sdk-dapp/pull/1088)
+
 ## [[v2.29.0-beta.10]](https://github.com/multiversx/mx-sdk-dapp/pull/1087)] - 2024-03-21
 - [ExperimentalWebviewProvider: "Cancel response" handling for the signTransactions and signMessage actions](https://github.com/multiversx/mx-sdk-dapp/pull/1086)
 

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "lodash.omit": "4.5.0",
     "lodash.throttle": "4.1.1",
     "lodash.uniqby": "4.7.0",
-    "protobufjs": "^7.2.6",
+    "protobufjs": "7.2.6",
     "qs": "6.10.3",
     "react-idle-timer": "5.0.0",
     "react-redux": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "lodash.omit": "4.5.0",
     "lodash.throttle": "4.1.1",
     "lodash.uniqby": "4.7.0",
+    "protobufjs": "^7.2.6",
     "qs": "6.10.3",
     "react-idle-timer": "5.0.0",
     "react-redux": "8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13073,7 +13073,7 @@ protobufjs@7.2.4:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
-protobufjs@^7.2.6:
+protobufjs@7.2.6:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.6.tgz#4a0ccd79eb292717aacf07530a07e0ed20278215"
   integrity sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13073,6 +13073,24 @@ protobufjs@7.2.4:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
+protobufjs@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.6.tgz#4a0ccd79eb292717aacf07530a07e0ed20278215"
+  integrity sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"


### PR DESCRIPTION
### Feature
protobufjs is mandatory because was moved in peerDeps in the latest version of the sdk-core
### Reproduce
Issue exists on version `2.29.0-beta.10` of sdk-dapp.

### Root cause

### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
