### PR TITLE
ExperimentalWebviewProvider: fix cancel actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [ExperimentalWebviewProvider: fix cancel actions](https://github.com/multiversx/mx-sdk-dapp/pull/1098)
 
 ## [[v2.29.0-beta.13]](https://github.com/multiversx/mx-sdk-dapp/pull/1093)] - 2024-03-23
 - [ExperimentalWebviewProvider: Fix cancel sign transactions flow](https://github.com/multiversx/mx-sdk-dapp/pull/1092)

--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -129,6 +129,7 @@ export class ExperimentalWebviewProvider implements IDappProvider {
     if (response.type == CrossWindowProviderResponseEnums.cancelResponse) {
       console.warn('Cancelled the transactions signing action');
       removeAllTransactionsToSign();
+      this.cancelAction();
       return null;
     }
 
@@ -155,6 +156,7 @@ export class ExperimentalWebviewProvider implements IDappProvider {
 
     if (response.type == CrossWindowProviderResponseEnums.cancelResponse) {
       console.warn('Cancelled the message signing action');
+      this.cancelAction();
       return null;
     }
 


### PR DESCRIPTION
### Issue
Login with web-wallet: The user is unable to sign other transactions or messages if previously cancelled an action.
### Reproduce
Issue exists on version `2.29.0-beta.15` of sdk-dapp.

### Root cause

### Fix
Add misssing cancelAction call on signTransactions and signMessage methods
### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
