### PR TITLE
Fix triggering logout from other dApps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [[v2.29.0-beta.17]](https://github.com/multiversx/mx-sdk-dapp/pull/1101)] - 2024-03-26
+- [ExperimentalWebviewProvider: fix cancel actions](https://github.com/multiversx/mx-sdk-dapp/pull/1100)
 
 ## [[v2.29.0-beta.16]](https://github.com/multiversx/mx-sdk-dapp/pull/1099)] - 2024-03-25
 - [ExperimentalWebviewProvider: fix cancel actions](https://github.com/multiversx/mx-sdk-dapp/pull/1098)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.29.0-beta.16",
+  "version": "2.29.0-beta.17",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/wrappers/DappProvider/CustomComponents.tsx
+++ b/src/wrappers/DappProvider/CustomComponents.tsx
@@ -14,6 +14,9 @@ export interface CustomComponentsType {
     component?: typeof TransactionsTracker;
     props?: TransactionsTrackerType;
   };
+  logoutListener?: {
+    component?: typeof LogoutListener;
+  };
 }
 
 export function CustomComponents({
@@ -23,16 +26,18 @@ export function CustomComponents({
 }) {
   const transactionSender = customComponents?.transactionSender;
   const transactionTracker = customComponents?.transactionTracker;
+  const logoutListener = customComponents?.logoutListener;
 
   const TxSender = transactionSender?.component ?? TransactionSender;
   const TxTracker = transactionTracker?.component ?? TransactionsTracker;
+  const LogOutListener = logoutListener?.component ?? LogoutListener;
 
   return (
     <>
       <TxSender {...transactionSender?.props} />
       <TxTracker {...transactionTracker?.props} />
 
-      <LogoutListener />
+      <LogOutListener />
     </>
   );
 }


### PR DESCRIPTION
### Feature
Allow configuring LogoutListener

### Reproduce
Issue exists on version `2.29.0-beta.16` of sdk-dapp.

### Root cause
Logout from a dapp using web wallet may trigger a logout action from same account logged into a different dapp

### Fix
Allow LogoutListener to be customized inside CustomComponents

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
