### PR TITLE
Fixed cross-window ledger re-login when device is locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.29.0-beta.19]](https://github.com/multiversx/mx-sdk-dapp/pull/1105)] - 2024-03-26
+- [Fixed cross-window ledger re-login when device is locked](https://github.com/multiversx/mx-sdk-dapp/pull/1104)
+
+
 ## [[v2.29.0-beta.18]](https://github.com/multiversx/mx-sdk-dapp/pull/1103)] - 2024-03-26
 - [Changed `logout()` with an extendable `options` parameter](https://github.com/multiversx/mx-sdk-dapp/pull/1102)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.29.0-beta.18",
+  "version": "2.29.0-beta.19",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -81,17 +81,8 @@ export async function logout(
     matchPath(location.pathname, callbackPathname) ||
     (isWalletProvider && isProviderInitialised)
   ) {
-    console.log('Prevent redirects');
     preventRedirects();
   }
-
-  console.log('Logout', {
-    address,
-    providerType,
-    callbackPathname,
-    isProviderInitialised
-  });
-  debugger;
 
   // We are already logged out, so we can redirect to the dapp
   if (!address && !isProviderInitialised) {

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -81,8 +81,17 @@ export async function logout(
     matchPath(location.pathname, callbackPathname) ||
     (isWalletProvider && isProviderInitialised)
   ) {
+    console.log('Prevent redirects');
     preventRedirects();
   }
+
+  console.log('Logout', {
+    address,
+    providerType,
+    callbackPathname,
+    isProviderInitialised
+  });
+  debugger;
 
   // We are already logged out, so we can redirect to the dapp
   if (!address && !isProviderInitialised) {
@@ -94,7 +103,12 @@ export async function logout(
 
   try {
     store.dispatch(logoutAction());
+
     if (isWalletProvider) {
+      if (!isProviderInitialised) {
+        return;
+      }
+
       // Allow redux store cleanup before redirect to web wallet
       return setTimeout(() => {
         provider.logout({ callbackUrl: url });


### PR DESCRIPTION
### Issue
The wallet automatically logs out (with redirect to different host) and replies with cancelled when logged in with a locked or unavailable ledger device.

### Reproduce
Issue exists on version `2.29.0-beta.18` of sdk-dapp.

### Root cause
When ledger is busy and we are logged in, the providerType appears as wallet and ledger initialisation fails. This causes the logout to be triggered and a redirect to the wallet URL, without trying to re-login.

### Fix
Prevent wallet redirects within the wallet provider `logout` method if the provider is not initialised

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
