### PR TITLE
Fix transactions toast status in case of some failed transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fix transactions toast status in case of some failed transactions](https://github.com/multiversx/mx-sdk-dapp/pull/1118)
+
 ## [[v2.29.0-beta.24]](https://github.com/multiversx/mx-sdk-dapp/pull/1115)] - 2024-04-01
 - [Added sdk-core to peer dependencies](https://github.com/multiversx/mx-sdk-dapp/pull/1114)
 

--- a/src/reduxStore/slices/transactionsSlice.ts
+++ b/src/reduxStore/slices/transactionsSlice.ts
@@ -171,7 +171,7 @@ export const transactionsSlice = createSlice({
 
         const areTransactionsFailed = state.signedTransactions[
           sessionId
-        ]?.transactions?.every((transaction) =>
+        ]?.transactions?.some((transaction) =>
           getIsTransactionFailed(transaction.status)
         );
 


### PR DESCRIPTION
### Issue
The transactions toast status remains in "pending" state when multiple transactions are tracked and some fail

### Reproduce
Issue exists on version `2.29.0-beta.24` of sdk-dapp.

### Root cause
Wrong status computation
### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
