### PR TITLE
Changed signTransactions to prevent re-fetching of account during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[v2.29.0-beta.27]](https://github.com/multiversx/mx-sdk-dapp/pull/1122)] - 2024-04-04
-- [Changed signTransactions to prevent re-fetching of account during validation](https://github.com/multiversx/mx-sdk-dapp/pull/1121)
+## [[v2.29.0-beta.27]](https://github.com/multiversx/mx-sdk-dapp/pull/1124)] - 2024-04-04
+- [Changed signTransactions to prevent re-fetching of account during validation](https://github.com/multiversx/mx-sdk-dapp/pull/1123)
 
 ## [[v2.29.0-beta.26]](https://github.com/multiversx/mx-sdk-dapp/pull/1120)] - 2024-04-03
 - [Added SWR API calls](https://github.com/multiversx/mx-sdk-dapp/pull/1117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.29.0-beta.27]](https://github.com/multiversx/mx-sdk-dapp/pull/1122)] - 2024-04-04
+- [Changed signTransactions to prevent re-fetching of account during validation](https://github.com/multiversx/mx-sdk-dapp/pull/1121)
+
 ## [[v2.29.0-beta.26]](https://github.com/multiversx/mx-sdk-dapp/pull/1120)] - 2024-04-03
 - [Added SWR API calls](https://github.com/multiversx/mx-sdk-dapp/pull/1117)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.29.0-beta.26",
+  "version": "2.29.0-beta.27",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/hooks/transactions/useSignMultipleTransactions.tsx
+++ b/src/hooks/transactions/useSignMultipleTransactions.tsx
@@ -14,7 +14,6 @@ import {
   Nullable,
   ScamInfoType
 } from 'types';
-import { getAccount } from 'utils/account/getAccount';
 import { getLedgerErrorCodes } from 'utils/internal/getLedgerErrorCodes';
 import { isTokenTransfer } from 'utils/transactions/isTokenTransfer';
 import {
@@ -22,6 +21,7 @@ import {
   getAreAllTransactionsSignedByGuardian
 } from './helpers';
 import { UseSignTransactionsWithDeviceReturnType } from './useSignTransactionsWithDevice';
+import { useGetAccountFromApi } from '../../apiCalls';
 
 export interface UseSignMultipleTransactionsPropsType {
   egldLabel: string;
@@ -94,15 +94,20 @@ export const useSignMultipleTransactions = ({
     });
 
   const isLastTransaction = currentStep === allTransactions.length - 1;
+  const currentTx = allTransactions[currentStep];
+  const sender = currentTransaction?.transaction?.getSender().toString();
+
+  // Skip account fetching if the sender is missing or same as current account
+  const { data: senderAccount } = useGetAccountFromApi(
+    !sender || sender === address ? null : sender
+  );
 
   const extractTransactionsInfo = async () => {
-    const tx = allTransactions[currentStep];
-
-    if (tx == null) {
+    if (currentTx == null) {
       return;
     }
 
-    const { transaction, multiTxData, transactionIndex } = tx;
+    const { transaction, multiTxData, transactionIndex } = currentTx;
     const dataField = transaction.getData().toString();
     const transactionTokenInfo = getTxInfoByDataField(
       transaction.getData().toString(),
@@ -111,21 +116,15 @@ export const useSignMultipleTransactions = ({
 
     const { tokenId } = transactionTokenInfo;
     const receiver = transaction.getReceiver().toString();
-    const sender = transaction.getSender().toString();
 
-    if (!sender) {
-      console.error(SENDER_DIFFERENT_THAN_LOGGED_IN_ADDRESS);
+    if (sender && sender !== address) {
+      const isValidSender = checkIsValidSender(senderAccount, address);
 
-      return onCancel?.();
-    }
+      if (!isValidSender) {
+        console.error(SENDER_DIFFERENT_THAN_LOGGED_IN_ADDRESS);
 
-    const senderAccount = await getAccount(sender);
-    const isValidSender = checkIsValidSender(senderAccount, address);
-
-    if (!isValidSender) {
-      console.error(SENDER_DIFFERENT_THAN_LOGGED_IN_ADDRESS);
-
-      return onCancel?.();
+        return onCancel?.();
+      }
     }
 
     const notSender = address !== receiver;
@@ -155,13 +154,13 @@ export const useSignMultipleTransactions = ({
 
   useEffect(() => {
     extractTransactionsInfo();
-  }, [currentStep, allTransactions]);
+  }, [currentTx, senderAccount]);
 
-  function reset() {
+  const reset = () => {
     setCurrentStep(0);
     setSignedTransactions(undefined);
     setWaitingForDevice(false);
-  }
+  };
 
   const sign = async () => {
     const existingSignedTransactions = Object.values(signedTransactions ?? {});
@@ -254,13 +253,13 @@ export const useSignMultipleTransactions = ({
 
   const isFirst = currentStep === 0;
 
-  function handleAbort() {
+  const handleAbort = () => {
     if (isFirst) {
       onCancel?.();
     } else {
       setCurrentStep((existing) => existing - 1);
     }
-  }
+  };
 
   const shouldContinueWithoutSigning = Boolean(
     currentTransaction?.transactionTokenInfo?.type &&
@@ -278,7 +277,7 @@ export const useSignMultipleTransactions = ({
     await signTx();
   };
 
-  function onNext() {
+  const onNext = () => {
     setCurrentStep((current) => {
       const nextStep = current + 1;
       if (nextStep > allTransactions?.length) {
@@ -286,9 +285,9 @@ export const useSignMultipleTransactions = ({
       }
       return nextStep;
     });
-  }
+  };
 
-  function onPrev() {
+  const onPrev = () => {
     setCurrentStep((current) => {
       const nextStep = current - 1;
       if (nextStep < 0) {
@@ -296,7 +295,7 @@ export const useSignMultipleTransactions = ({
       }
       return nextStep;
     });
-  }
+  };
 
   return {
     allTransactions,

--- a/src/hooks/transactions/useSignMultipleTransactions.tsx
+++ b/src/hooks/transactions/useSignMultipleTransactions.tsx
@@ -6,6 +6,7 @@ import {
   TransactionVersion
 } from '@multiversx/sdk-core';
 
+import { useGetAccountFromApi } from 'apiCalls/accounts/useGetAccountFromApi';
 import { SENDER_DIFFERENT_THAN_LOGGED_IN_ADDRESS } from 'constants/index';
 import { useParseMultiEsdtTransferData } from 'hooks/transactions/useParseMultiEsdtTransferData';
 import {
@@ -21,7 +22,6 @@ import {
   getAreAllTransactionsSignedByGuardian
 } from './helpers';
 import { UseSignTransactionsWithDeviceReturnType } from './useSignTransactionsWithDevice';
-import { useGetAccountFromApi } from '../../apiCalls';
 
 export interface UseSignMultipleTransactionsPropsType {
   egldLabel: string;

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -10,6 +10,7 @@ import { MetamaskProvider } from '@multiversx/sdk-metamask-provider/out/metamask
 import { CrossWindowProvider } from '@multiversx/sdk-web-wallet-cross-window-provider/out/CrossWindowProvider/CrossWindowProvider';
 
 import uniq from 'lodash/uniq';
+import { useGetAccountFromApi } from 'apiCalls/accounts/useGetAccountFromApi';
 import {
   ERROR_SIGNING,
   ERROR_SIGNING_TX,
@@ -53,7 +54,6 @@ import {
   checkIsValidSender
 } from './helpers';
 import { useSignTransactionsCommonData } from './useSignTransactionsCommonData';
-import { useGetAccountFromApi } from '../../apiCalls';
 
 export const useSignTransactions = () => {
   const dispatch = useDispatch();

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -41,8 +41,6 @@ import {
   LoginMethodsEnum,
   TransactionBatchStatusesEnum
 } from 'types/enums.types';
-
-import { getAccount } from 'utils/account/getAccount';
 import { builtCallbackUrl } from 'utils/transactions/builtCallbackUrl';
 import { parseTransactionAfterSigning } from 'utils/transactions/parseTransactionAfterSigning';
 import { getDefaultCallbackUrl } from 'utils/window';
@@ -55,6 +53,7 @@ import {
   checkIsValidSender
 } from './helpers';
 import { useSignTransactionsCommonData } from './useSignTransactionsCommonData';
+import { useGetAccountFromApi } from '../../apiCalls';
 
 export const useSignTransactions = () => {
   const dispatch = useDispatch();
@@ -81,7 +80,20 @@ export const useSignTransactions = () => {
 
   useParseSignedTransactions(onAbort);
 
-  function clearSignInfo(sessionId?: string) {
+  const senderAddresses = uniq(
+    transactionsToSign?.transactions
+      .map((tx) => tx.getSender().toString())
+      .filter((sender) => sender)
+  ) as string[];
+
+  const sender = senderAddresses?.[0];
+
+  // Skip account fetching if the sender is missing or same as current account
+  const { data: senderAccount } = useGetAccountFromApi(
+    !sender || sender === address ? null : sender
+  );
+
+  const clearSignInfo = (sessionId?: string) => {
     const isExtensionProvider = provider instanceof ExtensionProvider;
     const isCrossWindowProvider = provider instanceof CrossWindowProvider;
     const isMetamaskProvider = provider instanceof MetamaskProvider;
@@ -111,7 +123,7 @@ export const useSignTransactions = () => {
     if (isExperiementalWebviewProvider) {
       ExperimentalWebviewProvider.getInstance()?.cancelAction?.();
     }
-  }
+  };
 
   const onCancel = (errorMessage: string, sessionId?: string) => {
     const isSigningWithWalletConnectV2 =
@@ -296,20 +308,11 @@ export const useSignTransactions = () => {
       return;
     }
 
-    const senderAddresses = uniq(
-      transactions
-        .map((tx) => tx.getSender().toString())
-        .filter((sender) => sender)
-    ) as string[];
-
     if (senderAddresses.length > 1) {
       throw new Error('Multiple senders are not allowed');
     }
 
-    const sender = senderAddresses?.[0];
-
     if (sender && sender !== address) {
-      const senderAccount = sender ? await getAccount(sender) : null;
       const isValidSender = checkIsValidSender(senderAccount, address);
 
       if (!isValidSender) {
@@ -366,7 +369,7 @@ export const useSignTransactions = () => {
     } else {
       isSigningRef.current = false;
     }
-  }, [transactionsToSign, hasTransactions]);
+  }, [transactionsToSign, hasTransactions, senderAccount]);
 
   return {
     error,


### PR DESCRIPTION
### Issue
During transactions validation, the `getAccount` method is called multiple times, causes performance issues.

### Reproduce
Issue exists on version `2.29.0` of sdk-dapp.

### Fix
Get account by sender address only once in the beginning of the hook and reuse it withitn the validation steps

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
