### PR TITLE
ExperimentalWebviewProvider: fix cancel action on sign transactions flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [ExperimentalWebviewProvider: fix cancel action on sign transactions flow](https://github.com/multiversx/mx-sdk-dapp/pull/1125)
 
 ## [[v2.29.0-beta.26]](https://github.com/multiversx/mx-sdk-dapp/pull/1120)] - 2024-04-03
 - [Added SWR API calls](https://github.com/multiversx/mx-sdk-dapp/pull/1117)

--- a/src/hooks/transactions/useSignTransactionsCommonData.tsx
+++ b/src/hooks/transactions/useSignTransactionsCommonData.tsx
@@ -8,6 +8,7 @@ import { useGetAccount } from 'hooks/account';
 import { useGetAccountProvider } from 'hooks/account/useGetAccountProvider';
 import { useParseSignedTransactions } from 'hooks/transactions/useParseSignedTransactions';
 
+import { ExperimentalWebviewProvider } from 'providers/experimentalWebViewProvider';
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
 import {
   signTransactionsCancelMessageSelector,
@@ -68,6 +69,7 @@ export const useSignTransactionsCommonData = () => {
     const isExtensionProvider = provider instanceof ExtensionProvider;
     const isCrossWindowProvider = provider instanceof CrossWindowProvider;
     const isMetamaskProvider = provider instanceof MetamaskProvider;
+    const isWebviewProvider = provider instanceof ExperimentalWebviewProvider;
 
     dispatch(clearAllTransactionsToSign());
     dispatch(clearTransactionsInfoForSessionId(sessionId));
@@ -88,6 +90,10 @@ export const useSignTransactionsCommonData = () => {
 
     if (isCrossWindowProvider) {
       CrossWindowProvider.getInstance()?.cancelAction?.();
+    }
+
+    if (isWebviewProvider) {
+      ExperimentalWebviewProvider.getInstance()?.cancelAction?.();
     }
   }
 


### PR DESCRIPTION
### Issue
Missing trigger of the cancel action when the user aborts signing transactions
### Reproduce
Issue exists on version `2.29.0-beta.27` of sdk-dapp.
Missing implementation
### Root cause

### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
