### PR TITLE
Sync signed transactions fields with the corresponding fields from the API

### DIFF
--- a/src/hooks/transactions/batch/tracker/useUpdateBatch.ts
+++ b/src/hooks/transactions/batch/tracker/useUpdateBatch.ts
@@ -48,7 +48,8 @@ export function useUpdateBatch() {
           updateSignedTransactionStatus({
             sessionId,
             status: apiTx.status as TransactionServerStatusesEnum,
-            transactionHash: transaction.hash
+            transactionHash: transaction.hash,
+            serverTransaction: apiTx
           })
         );
       }

--- a/src/hooks/transactions/useCheckTransactionStatus/checkBatch.ts
+++ b/src/hooks/transactions/useCheckTransactionStatus/checkBatch.ts
@@ -4,6 +4,7 @@ import { store } from 'reduxStore/store';
 import {
   CustomTransactionInformation,
   GetTransactionsByHashesReturnType,
+  ServerTransactionType,
   SignedTransactionsBodyType
 } from 'types';
 import { TransactionServerStatusesEnum } from 'types/enums.types';
@@ -84,7 +85,9 @@ function manageTransaction({
           sessionId,
           status,
           transactionHash: hash,
-          inTransit
+          inTransit,
+          serverTransaction:
+            serverTransaction as unknown as ServerTransactionType
         })
       );
       return;
@@ -105,7 +108,9 @@ function manageTransaction({
                 sessionId,
                 status: TransactionServerStatusesEnum.success,
                 transactionHash: hash,
-                inTransit
+                inTransit,
+                serverTransaction:
+                  serverTransaction as unknown as ServerTransactionType
               })
             ),
           customTransactionInformation?.completedTransactionsDelay
@@ -117,7 +122,9 @@ function manageTransaction({
             sessionId,
             status,
             transactionHash: hash,
-            inTransit
+            inTransit,
+            serverTransaction:
+              serverTransaction as unknown as ServerTransactionType
           })
         );
       }

--- a/src/hooks/transactions/useCheckTransactionStatus/manageFailedTransactions.ts
+++ b/src/hooks/transactions/useCheckTransactionStatus/manageFailedTransactions.ts
@@ -3,7 +3,7 @@ import {
   updateSignedTransactionStatus
 } from 'reduxStore/slices';
 import { store } from 'reduxStore/store';
-import { SmartContractResult } from 'types';
+import { ServerTransactionType, SmartContractResult } from 'types';
 import {
   TransactionBatchStatusesEnum,
   TransactionServerStatusesEnum
@@ -28,7 +28,8 @@ export function manageFailedTransactions({
       sessionId,
       status: TransactionServerStatusesEnum.fail,
       errorMessage: resultWithError?.returnMessage,
-      inTransit: false
+      inTransit: false,
+      serverTransaction: resultWithError as unknown as ServerTransactionType
     })
   );
   store.dispatch(

--- a/src/reduxStore/slices/transactionsSlice.ts
+++ b/src/reduxStore/slices/transactionsSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { REHYDRATE } from 'redux-persist';
 import {
   CustomTransactionInformation,
+  ServerTransactionType,
   SignedTransactionsBodyType,
   SignedTransactionsType,
   SignedTransactionType,
@@ -36,6 +37,7 @@ export interface UpdateSignedTransactionStatusPayloadType {
   sessionId: string;
   transactionHash: string;
   status: TransactionServerStatusesEnum;
+  serverTransaction?: ServerTransactionType;
   errorMessage?: string;
   inTransit?: boolean;
 }
@@ -146,14 +148,21 @@ export const transactionsSlice = createSlice({
       state: TransactionsSliceStateType,
       action: PayloadAction<UpdateSignedTransactionStatusPayloadType>
     ) => {
-      const { sessionId, status, errorMessage, transactionHash, inTransit } =
-        action.payload;
+      const {
+        sessionId,
+        status,
+        errorMessage,
+        transactionHash,
+        serverTransaction,
+        inTransit
+      } = action.payload;
       const transactions = state.signedTransactions?.[sessionId]?.transactions;
       if (transactions != null) {
         state.signedTransactions[sessionId].transactions = transactions.map(
           (transaction) => {
             if (transaction.hash === transactionHash) {
               return {
+                ...(serverTransaction ?? {}),
                 ...transaction,
                 status,
                 errorMessage,


### PR DESCRIPTION
### Feature
Sync signed transactions fields with the corresponding fields from the API
### Reproduce
Issue exists on version `2.29.0-beta.29` of sdk-dapp.


### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
