### PR TITLE
ExperimentalWebviewProvider: fix mobile response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- [ExperimentalWebviewProvider: fix mobile response](https://github.com/multiversx/mx-sdk-dapp/pull/1140)
+-
 ## [[v2.30.0]](https://github.com/multiversx/mx-sdk-dapp/pull/1139)] - 2024-04-09
 - [ExperimentalWebviewProvider: Enhance mobile webview compatibility to provide comprehensive support.](https://github.com/multiversx/mx-sdk-dapp/pull/1138)
 

--- a/src/providers/experimentalWebViewProvider/helpers/getSafeDocument.ts
+++ b/src/providers/experimentalWebViewProvider/helpers/getSafeDocument.ts
@@ -1,0 +1,3 @@
+export const getSafeDocument = () => {
+  return typeof document !== 'undefined' ? document : ({} as any);
+};

--- a/src/providers/experimentalWebViewProvider/helpers/getSafeWindow.ts
+++ b/src/providers/experimentalWebViewProvider/helpers/getSafeWindow.ts
@@ -1,0 +1,3 @@
+export const getSafeWindow = () => {
+  return typeof window !== 'undefined' ? window : ({} as any);
+};

--- a/src/providers/experimentalWebViewProvider/helpers/isMobileWebview.ts
+++ b/src/providers/experimentalWebViewProvider/helpers/isMobileWebview.ts
@@ -1,0 +1,6 @@
+import { getSafeWindow } from './getSafeWindow';
+
+export const isMobileWebview = () => {
+  const safeWindow = getSafeWindow();
+  return safeWindow.ReactNativeWebView || safeWindow.webkit;
+};

--- a/src/providers/experimentalWebViewProvider/helpers/webviewProviderEventHandler.ts
+++ b/src/providers/experimentalWebViewProvider/helpers/webviewProviderEventHandler.ts
@@ -2,23 +2,39 @@ import {
   CrossWindowProviderResponseEnums,
   ReplyWithPostMessagePayloadType
 } from '@multiversx/sdk-web-wallet-cross-window-provider/out/types';
+import { getSafeDocument } from './getSafeDocument';
+import { getSafeWindow } from './getSafeWindow';
 import { getTargetOrigin } from './getTargetOrigin';
+import { isMobileWebview } from './isMobileWebview';
+
+export type WebviewProviderEventDataType<
+  T extends CrossWindowProviderResponseEnums
+> = {
+  type: T;
+  payload: ReplyWithPostMessagePayloadType<T>;
+};
 
 export const webviewProviderEventHandler =
   <T extends CrossWindowProviderResponseEnums>(
     action: T,
-    resolve: (value: {
-      type: T;
-      payload: ReplyWithPostMessagePayloadType<T>;
-    }) => void
+    resolve: (value: WebviewProviderEventDataType<T>) => void
   ) =>
-  (
-    event: MessageEvent<{
+  (event: MessageEvent<WebviewProviderEventDataType<T> | string>) => {
+    let eventData = event.data;
+
+    try {
+      eventData =
+        isMobileWebview() && typeof eventData === 'string'
+          ? JSON.parse(eventData)
+          : eventData;
+    } catch (err) {
+      console.error('error parsing eventData', eventData);
+    }
+
+    const { type, payload } = eventData as {
       type: T;
       payload: ReplyWithPostMessagePayloadType<T>;
-    }>
-  ) => {
-    const { type, payload } = event.data;
+    };
 
     if (event.origin != getTargetOrigin()) {
       console.error('origin not accepted', {
@@ -35,9 +51,14 @@ export const webviewProviderEventHandler =
       return;
     }
 
-    window.removeEventListener(
+    getSafeWindow().removeEventListener?.(
       'message',
       webviewProviderEventHandler(action, resolve)
     );
+    getSafeDocument().removeEventListener?.(
+      'message',
+      webviewProviderEventHandler(action, resolve)
+    );
+
     resolve({ type, payload });
   };


### PR DESCRIPTION
### Issue
Mobile webview supports only string messages. We have to deserialize the event data in order to extract the fields from the response.
### Reproduce
Issue exists on version `2.30.0` of sdk-dapp.

### Root cause
Missing deserialization
### Fix

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
