### PR TITLE
Downgrade sdk-web-wallet-cross-window-provider to non-lit environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.31.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1156)] - 2024-04-18
+- [Removed sdk-web-wallet-cross-window-provider with `lit` webcomponents](https://github.com/multiversx/mx-sdk-dapp/pull/1155)
+
 ## [[v2.31.4]](https://github.com/multiversx/mx-sdk-dapp/pull/1154)] - 2024-04-18
 
 - [Removed unnecessary address check](https://github.com/multiversx/mx-sdk-dapp/pull/1153)

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@multiversx/sdk-opera-provider": "1.0.0-alpha.1",
     "@multiversx/sdk-wallet": "4.2.0",
     "@multiversx/sdk-wallet-connect-provider": "4.1.2",
-    "@multiversx/sdk-web-wallet-cross-window-provider": "0.0.37",
+    "@multiversx/sdk-web-wallet-cross-window-provider": "0.0.33",
     "@multiversx/sdk-web-wallet-provider": "3.2.1",
     "@multiversx/sdk-webview-provider": "0.0.8",
     "@reduxjs/toolkit": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.31.4",
+  "version": "2.31.5",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,10 +2446,10 @@
     tweetnacl "1.0.3"
     uuid "8.3.2"
 
-"@multiversx/sdk-web-wallet-cross-window-provider@0.0.37":
-  version "0.0.37"
-  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-cross-window-provider/-/sdk-web-wallet-cross-window-provider-0.0.37.tgz#17838cbce4a10bb85b1077d87d20c21cfdca6691"
-  integrity sha512-1z8UY8H6HEE3ug4E/1mWhGbLAbll5TyyYDSSA4whQ/eqj5MbrAOjVonkh+a9pVQjx6wQuXmhdfMXIgdWHkzWgQ==
+"@multiversx/sdk-web-wallet-cross-window-provider@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-cross-window-provider/-/sdk-web-wallet-cross-window-provider-0.0.33.tgz#798fd76050b24fd1ec4c4788da83667420e9f114"
+  integrity sha512-l2rMzcYji8abySdrrIFkTOPsOYw2UvmlHnJfbU+PpKcwmF0vkwSUIS+XP8FqF00kwDyH2oGHGqZ7aoZRX6wSVw==
   dependencies:
     "@types/jest" "^29.5.11"
     "@types/qs" "6.9.10"


### PR DESCRIPTION
### Issue
Lit in sdk-web-wallet-cross-window-provider breaks development build of dApps

### Reproduce
Issue exists on version `2.31.4` of sdk-dapp.

### Root cause
Uncaught SyntaxError: Identifier 'global' has already been declared

### Fix
To be investigated in a future release


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
