### PR TITLE
Fixed `AuthenticatedRoutesWrapper` redirects to unlock route during webview login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Fixed `AuthenticatedRoutesWrapper` redirects to unlock route during webview login](https://github.com/multiversx/mx-sdk-dapp/pull/1157su)
+- [Fixed `AuthenticatedRoutesWrapper` redirects to unlock route during webview login](https://github.com/multiversx/mx-sdk-dapp/pull/1160)
 
 ## [[v2.31.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1156)] - 2024-04-18
 - [Removed sdk-web-wallet-cross-window-provider with `lit` webcomponents](https://github.com/multiversx/mx-sdk-dapp/pull/1155)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed `AuthenticatedRoutesWrapper` redirects to unlock route during webview login](https://github.com/multiversx/mx-sdk-dapp/pull/1157su)
+
 ## [[v2.31.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1156)] - 2024-04-18
 - [Removed sdk-web-wallet-cross-window-provider with `lit` webcomponents](https://github.com/multiversx/mx-sdk-dapp/pull/1155)
 

--- a/src/wrappers/AuthenticatedRoutesWrapper/AuthenticatedRoutesWrapper.tsx
+++ b/src/wrappers/AuthenticatedRoutesWrapper/AuthenticatedRoutesWrapper.tsx
@@ -11,6 +11,7 @@ import { getSearchParamAddress } from 'utils/account/getSearchParamAddress';
 import { isWindowAvailable } from 'utils/isWindowAvailable';
 import { safeRedirect } from 'utils/redirect';
 import { matchRoute } from './helpers/matchRoute';
+import { getWebviewToken } from 'utils/account/getWebviewToken';
 
 export const AuthenticatedRoutesWrapper = ({
   children,
@@ -29,6 +30,7 @@ export const AuthenticatedRoutesWrapper = ({
   const isLoggedIn = useSelector(isLoggedInSelector);
   const isAccountLoading = useSelector(isAccountLoadingSelector);
   const walletLogin = useSelector(walletLoginSelector);
+  const isWebviewLogin = Boolean(getWebviewToken());
 
   const getLocationPathname = () => {
     if (isWindowAvailable()) {
@@ -43,7 +45,10 @@ export const AuthenticatedRoutesWrapper = ({
   );
 
   const shouldRedirect =
-    isOnAuthenticatedRoute && !isLoggedIn && walletLogin == null;
+    isOnAuthenticatedRoute &&
+    !isLoggedIn &&
+    walletLogin == null &&
+    !isWebviewLogin;
 
   useEffect(() => {
     if (!shouldRedirect) {


### PR DESCRIPTION
### Issue
Cannot login with `accessToken` in URL (Webview login)

### Reproduce
Issue exists on version `2.31.6` of sdk-dapp.

### Root cause
`AuthenticatedRoutesWrapper` does not check for `accessToken` and redirects to `unlockRoute` regardless. Webview login with `accessToken` is a bit laggy.

### Fix
Added an additional check to the `shouldRedirect` flag, using `getWebviewToken` method.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
