### PR TITLE
fix webview custom message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+  - [Fixed webview custom message method](https://github.com/multiversx/mx-sdk-dapp/pull/1170)
+
 ## [[v2.32.3]](https://github.com/multiversx/mx-sdk-dapp/pull/1169)] - 2024-04-25
 - [Fixed sdk-web-wallet-cross-window-provider `console.log`](https://github.com/multiversx/mx-sdk-dapp/pull/1169)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.32.3",
+  "version": "2.32.4",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -94,5 +94,14 @@ export class ExperimentalWebviewProvider implements IDappProvider {
     return await this._provider.isConnected();
   };
 
+  sendCustomRequest = async (payload: {
+    request: { method: string; params: any };
+  }) => {
+    this._provider.sendPostMessage({
+      type: payload.request.method as any,
+      payload: payload.request.params
+    });
+  };
+
   getAddress = providerNotInitializedError('getAddress');
 }


### PR DESCRIPTION
### Issue
 Send custom message method was not implemented on webview provider

### Reproduce
Issue exists on version `2.32.3` of sdk-dapp.

### Fix
Implement send custom request method


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
