### PR TITLE
Fix custom environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [[v2.32.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1175)] - 2024-05-22
+- [Fixed signing in custom environment](https://github.com/multiversx/mx-sdk-dapp/pull/1174)
 
-## [[v2.32.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1173)] - 2024-03-14
+## [[v2.32.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1173)] - 2024-05-14
 - [Fixed username trim removes information after dot](https://github.com/multiversx/mx-sdk-dapp/pull/1172)
 
 ## [[v2.32.4]](https://github.com/multiversx/mx-sdk-dapp/pull/1171)] - 2024-05-13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.32.5",
+  "version": "2.32.6",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { getEnvironmentForChainId, getNetworkConfigFromApi } from 'apiCalls';
+import { getNetworkConfigFromApi } from 'apiCalls';
 import { useLoginService } from 'hooks/login/useLoginService';
 import { useWalletConnectV2Login } from 'hooks/login/useWalletConnectV2Login';
 import {
@@ -280,9 +280,7 @@ export function ProviderInitializer() {
   }
 
   async function initializeProvider() {
-    const isValidEnvironment = getEnvironmentForChainId(chainID);
-
-    if (loginMethod == null || initalizingLedger || !isValidEnvironment) {
+    if (loginMethod == null || initalizingLedger) {
       return;
     }
 


### PR DESCRIPTION
### Issue
Provider not initialized in custom environment with chain ID other than `1 / D / T`

### Fix
Remove `getEnvironmentForChainId` check in `ProviderInitializer` 

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
