### PR TITLE
Fixed walletconnect infinite loading and wallet redirect when using custom network config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed walletconnect infinite loading when using custom network config](https://github.com/multiversx/mx-sdk-dapp/pull/1180)
+
 ## [[v2.32.8]](https://github.com/multiversx/mx-sdk-dapp/pull/1179)] - 2024-05-29
 - [Fixed web wallet url logout no redirect](https://github.com/multiversx/mx-sdk-dapp/pull/1178)
 - [Upgrade sdk-web-wallet-cross-window-provider and remove lit dependency](https://github.com/multiversx/mx-sdk-dapp/pull/1179)

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -32,6 +32,7 @@ import {
   OnProviderLoginType
 } from '../../types/login.types';
 import { useLoginService } from './useLoginService';
+import { getIsProviderEqualTo } from 'utils/account/getIsProviderEqualTo';
 
 export enum WalletConnectV2Error {
   invalidAddress = 'Invalid address',
@@ -86,12 +87,12 @@ export const useWalletConnectV2Login = ({
   >([]);
   const [sessionProvider, setSessionProvider] =
     useState<WalletConnectV2Provider | null>(null);
-
   const { provider } = useGetAccountProvider();
   const walletConnectV2RelayAddress = useSelector(walletConnectV2RelaySelector);
   const walletConnectV2ProjectId = useSelector(
     walletConnectV2ProjectIdSelector
   );
+
   const walletConnectV2Options = useSelector(walletConnectV2OptionsSelector);
   const walletConnectDeepLink = useSelector(walletConnectDeepLinkSelector);
   const dappLogoutRoute = useSelector(logoutRouteSelector);
@@ -99,7 +100,7 @@ export const useWalletConnectV2Login = ({
   const providerRef = useRef<any>(provider);
   const isInitialisingRef = useRef<boolean>(false);
   const mounted = useRef(false);
-
+  const isWalletProvider = getIsProviderEqualTo(LoginMethodsEnum.wallet);
   const logoutRoute = providerLogoutRoute ?? dappLogoutRoute ?? '/';
   const dappMethods: string[] = [
     WalletConnectOptionalMethodsEnum.CANCEL_ACTION,
@@ -236,12 +237,20 @@ export const useWalletConnectV2Login = ({
         loginService.setLoginToken(token);
       }
 
+      if (isWalletProvider) {
+        // Prevent redirecting to wallet login hook
+        setIsLoading(true);
+        await initiateLogin();
+
+        return;
+      }
+
       try {
         await providerRef.current?.login({ approval, token });
       } catch (err) {
+        console.error(WalletConnectV2Error.userRejectedExisting, err);
         setError(WalletConnectV2Error.userRejectedExisting);
         setIsLoading(true);
-
         await initiateLogin();
       }
     } catch (err) {
@@ -272,17 +281,18 @@ export const useWalletConnectV2Login = ({
     const chainId = await waitForChainID({ maxRetries: 15 });
 
     if (!chainId) {
+      console.error(WalletConnectV2Error.invalidChainID);
       setError(WalletConnectV2Error.invalidChainID);
       return;
     }
 
     if (!walletConnectV2ProjectId || !walletConnectV2RelayAddress) {
+      console.error(WalletConnectV2Error.invalidConfig);
       setError(WalletConnectV2Error.invalidConfig);
       return;
     }
 
     const isLoggedIn = getIsLoggedIn();
-
     const cannotLogin = mounted.current === false && !isLoggedIn;
     const isInitialized = providerRef.current?.isInitialized?.();
 
@@ -378,13 +388,17 @@ export const useWalletConnectV2Login = ({
         loginService.setLoginToken(token);
       }
 
+      if (isWalletProvider) {
+        // Prevent redirecting to wallet login hook
+        return;
+      }
+
       try {
         await providerRef.current?.login({ approval, token });
       } catch (err) {
+        console.error(WalletConnectV2Error.userRejected, err);
         setError(WalletConnectV2Error.userRejected);
         setIsLoading(true);
-
-        await initiateLogin();
       }
     } catch (err) {
       console.error(WalletConnectV2Error.connectError, err);
@@ -404,7 +418,7 @@ export const useWalletConnectV2Login = ({
   }, []);
 
   useEffect(() => {
-    setIsLoading(!Boolean(wcUri));
+    setIsLoading(!wcUri);
   }, [wcUri]);
 
   useEffect(() => {

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -32,7 +32,6 @@ import {
   OnProviderLoginType
 } from '../../types/login.types';
 import { useLoginService } from './useLoginService';
-import { getIsProviderEqualTo } from 'utils/account/getIsProviderEqualTo';
 
 export enum WalletConnectV2Error {
   invalidAddress = 'Invalid address',
@@ -100,7 +99,6 @@ export const useWalletConnectV2Login = ({
   const providerRef = useRef<any>(provider);
   const isInitialisingRef = useRef<boolean>(false);
   const mounted = useRef(false);
-  const isWalletProvider = getIsProviderEqualTo(LoginMethodsEnum.wallet);
   const logoutRoute = providerLogoutRoute ?? dappLogoutRoute ?? '/';
   const dappMethods: string[] = [
     WalletConnectOptionalMethodsEnum.CANCEL_ACTION,
@@ -146,7 +144,7 @@ export const useWalletConnectV2Login = ({
         return;
       }
 
-      const address = await providerRef.current?.getAddress();
+      const address = await providerRef.current?.getAddress?.();
 
       if (!address) {
         console.warn('Login cancelled.');
@@ -237,7 +235,11 @@ export const useWalletConnectV2Login = ({
         loginService.setLoginToken(token);
       }
 
-      if (isWalletProvider) {
+      const providerType = providerRef.current
+        ? getProviderType(providerRef.current)
+        : false;
+
+      if (providerType !== LoginMethodsEnum.walletconnectv2) {
         // Prevent redirecting to wallet login hook
         setIsLoading(true);
         await initiateLogin();
@@ -388,8 +390,14 @@ export const useWalletConnectV2Login = ({
         loginService.setLoginToken(token);
       }
 
-      if (isWalletProvider) {
+      const providerType = providerRef.current
+        ? getProviderType(providerRef.current)
+        : false;
+
+      if (providerType !== LoginMethodsEnum.walletconnectv2) {
         // Prevent redirecting to wallet login hook
+        setIsLoading(true);
+        await initiateLogin();
         return;
       }
 

--- a/src/utils/waitForChainID.ts
+++ b/src/utils/waitForChainID.ts
@@ -1,4 +1,3 @@
-import { getEnvironmentForChainId } from 'apiCalls';
 import { chainIDSelector } from 'reduxStore/selectors';
 import { store } from 'reduxStore/store';
 
@@ -13,9 +12,8 @@ export const waitForChainID = ({
     // Function to periodically check the value of chainID
     const checkChainID = () => {
       const chainID = chainIDSelector(store.getState());
-      const isValidEnvironment = getEnvironmentForChainId(chainID);
 
-      if (Boolean(isValidEnvironment)) {
+      if (chainID) {
         resolve(chainID);
         return;
       }


### PR DESCRIPTION
### Issues
- infinite loading when using custom network config;
- redirect to wallet address login hook after logout when using custom network config.

### Reproduce
- Go to web wallet unlock page;
- Add a custom network (https://mx-api-sov-ovh.elrond.ro)
- Login and then logout

Actual result: Infinite loading on wallet connect and user is redirected to https://wallet.voyager1.dev/hook/login
Expected result: wallet connect is loaded successfully and the user can relogin into the wallet without any other redirects

### Root cause

- invalid chainId is set when using different chain ID then mainnet, testnet, and devnet;
- wallet provider is set instead of wallet connect provider. Wallet provider attempts login.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
