### PR TITLE
Fixed logged in address is different than address from nativeAuth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.32.10]](https://github.com/multiversx/mx-sdk-dapp/pull/1182)] - 2024-06-03
+- [Fixed logged in address is different than address from nativeAuth token](https://github.com/multiversx/mx-sdk-dapp/pull/1181)
+
 ## [[v2.32.9]](https://github.com/multiversx/mx-sdk-dapp/pull/1180)] - 2024-05-30
 - [Fixed walletconnect infinite loading when using custom network config](https://github.com/multiversx/mx-sdk-dapp/pull/1180)
 

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -135,7 +135,7 @@ export function ProviderInitializer() {
     }
   }
 
-  async function checkAddress() {
+  function checkAddress() {
     if (!tokenLogin?.nativeAuthToken) {
       return;
     }

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -35,8 +35,7 @@ import {
   setChainID,
   setTokenLogin,
   setIsWalletConnectV2Initialized,
-  setAddress,
-  resetAccount
+  setAddress
 } from 'reduxStore/slices';
 import { decodeNativeAuthToken } from 'services/nativeAuth/helpers';
 import { LoginMethodsEnum } from 'types/enums.types';
@@ -45,7 +44,8 @@ import {
   getAccount,
   getLatestNonce,
   newWalletProvider,
-  emptyProvider
+  emptyProvider,
+  refreshAccount
 } from 'utils/account';
 import { parseNavigationParams } from 'utils/parseNavigationParams';
 
@@ -136,7 +136,7 @@ export function ProviderInitializer() {
     }
   }
 
-  function checkAddress() {
+  async function checkAddress() {
     if (!tokenLogin?.nativeAuthToken) {
       return;
     }
@@ -144,8 +144,8 @@ export function ProviderInitializer() {
     const decoded = decodeNativeAuthToken(tokenLogin?.nativeAuthToken);
 
     if (decoded?.address && decoded.address !== address) {
-      dispatch(resetAccount());
       dispatch(setAddress(decoded.address));
+      await refreshAccount();
     }
   }
 

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -46,7 +46,7 @@ import {
 } from 'utils/account';
 import { parseNavigationParams } from 'utils/parseNavigationParams';
 
-import { useWebViewLogin } from '../../hooks/login/useWebViewLogin';
+import { useWebViewLogin } from 'hooks/login/useWebViewLogin';
 import {
   getOperaProvider,
   getCrossWindowProvider,
@@ -55,6 +55,7 @@ import {
   getMetamaskProvider
 } from './helpers';
 import { useSetLedgerProvider } from './hooks';
+import { decodeNativeAuthToken } from 'services/nativeAuth/helpers';
 
 let initalizingLedger = false;
 
@@ -95,7 +96,11 @@ export function ProviderInitializer() {
 
   useEffect(() => {
     initializeProvider();
-  }, [loginMethod, chainID]);
+  }, [address, loginMethod, chainID]);
+
+  useEffect(() => {
+    checkAddress();
+  }, [tokenLogin?.nativeAuthToken, address]);
 
   useEffect(() => {
     fetchAccount();
@@ -127,6 +132,18 @@ export function ProviderInitializer() {
           version: ledgerData.version
         })
       );
+    }
+  }
+
+  async function checkAddress() {
+    if (!tokenLogin?.nativeAuthToken) {
+      return;
+    }
+
+    const decoded = decodeNativeAuthToken(tokenLogin?.nativeAuthToken);
+
+    if (decoded?.address && decoded.address !== address) {
+      dispatch(setAddress(decoded.address));
     }
   }
 

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -35,7 +35,8 @@ import {
   setChainID,
   setTokenLogin,
   setIsWalletConnectV2Initialized,
-  setAddress
+  setAddress,
+  resetAccount
 } from 'reduxStore/slices';
 import { decodeNativeAuthToken } from 'services/nativeAuth/helpers';
 import { LoginMethodsEnum } from 'types/enums.types';
@@ -143,6 +144,7 @@ export function ProviderInitializer() {
     const decoded = decodeNativeAuthToken(tokenLogin?.nativeAuthToken);
 
     if (decoded?.address && decoded.address !== address) {
+      dispatch(resetAccount());
       dispatch(setAddress(decoded.address));
     }
   }

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { getNetworkConfigFromApi } from 'apiCalls';
 import { useLoginService } from 'hooks/login/useLoginService';
 import { useWalletConnectV2Login } from 'hooks/login/useWalletConnectV2Login';
+import { useWebViewLogin } from 'hooks/login/useWebViewLogin';
 import {
   setAccountProvider,
   setExternalProviderAsAccountProvider
@@ -36,6 +37,7 @@ import {
   setIsWalletConnectV2Initialized,
   setAddress
 } from 'reduxStore/slices';
+import { decodeNativeAuthToken } from 'services/nativeAuth/helpers';
 import { LoginMethodsEnum } from 'types/enums.types';
 import {
   getAddress,
@@ -46,7 +48,6 @@ import {
 } from 'utils/account';
 import { parseNavigationParams } from 'utils/parseNavigationParams';
 
-import { useWebViewLogin } from 'hooks/login/useWebViewLogin';
 import {
   getOperaProvider,
   getCrossWindowProvider,
@@ -55,7 +56,6 @@ import {
   getMetamaskProvider
 } from './helpers';
 import { useSetLedgerProvider } from './hooks';
-import { decodeNativeAuthToken } from 'services/nativeAuth/helpers';
 
 let initalizingLedger = false;
 

--- a/src/reduxStore/slices/accountInfoSlice.ts
+++ b/src/reduxStore/slices/accountInfoSlice.ts
@@ -156,8 +156,7 @@ export const accountInfoSlice = createSlice({
         timestamp: Date.now(),
         data: action.payload
       };
-    },
-    resetAccount: () => initialState
+    }
   },
   extraReducers: (builder) => {
     builder.addCase(logoutAction, () => {
@@ -203,8 +202,7 @@ export const {
   setIsAccountLoading,
   setAccountLoadingError,
   setWebsocketEvent,
-  setWebsocketBatchEvent,
-  resetAccount
+  setWebsocketBatchEvent
 } = accountInfoSlice.actions;
 
 export default accountInfoSlice.reducer;

--- a/src/reduxStore/slices/accountInfoSlice.ts
+++ b/src/reduxStore/slices/accountInfoSlice.ts
@@ -156,7 +156,8 @@ export const accountInfoSlice = createSlice({
         timestamp: Date.now(),
         data: action.payload
       };
-    }
+    },
+    resetAccount: () => initialState
   },
   extraReducers: (builder) => {
     builder.addCase(logoutAction, () => {
@@ -202,7 +203,8 @@ export const {
   setIsAccountLoading,
   setAccountLoadingError,
   setWebsocketEvent,
-  setWebsocketBatchEvent
+  setWebsocketBatchEvent,
+  resetAccount
 } = accountInfoSlice.actions;
 
 export default accountInfoSlice.reducer;


### PR DESCRIPTION
### Issue
User may be logged in with address different than the one from nativeAuth token on store rehydrate

### Fix
Ensure the address from the nativeAuth token is the same with the one from the account in store

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
