### PR TITLE
Removed address check for impersonate action in `ProviderInitializer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[v2.33.1]](https://github.com/multiversx/mx-sdk-dapp/pull/1186)] - 2024-06-06
-- [Removed address check for impersonate action in `ProviderInitializer`](https://github.com/multiversx/mx-sdk-dapp/pull/1185)
+## [[v2.33.1]](https://github.com/multiversx/mx-sdk-dapp/pull/1187)] - 2024-06-06
+- [Removed address check for impersonate action in `ProviderInitializer`](https://github.com/multiversx/mx-sdk-dapp/pull/1186)
 
 ## [[v2.33.0]](https://github.com/multiversx/mx-sdk-dapp/pull/1185)] - 2024-06-06
 - [Added `XaliasCrossWindowLoginButton`](https://github.com/multiversx/mx-sdk-dapp/pull/1184)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.33.1]](https://github.com/multiversx/mx-sdk-dapp/pull/1186)] - 2024-06-06
+- [Removed address check for impersonate action in `ProviderInitializer`](https://github.com/multiversx/mx-sdk-dapp/pull/1185)
+
 ## [[v2.33.0]](https://github.com/multiversx/mx-sdk-dapp/pull/1185)] - 2024-06-06
 - [Added `XaliasCrossWindowLoginButton`](https://github.com/multiversx/mx-sdk-dapp/pull/1184)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.33.0",
+  "version": "2.33.1",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -137,7 +137,11 @@ export function ProviderInitializer() {
   }
 
   async function checkAddress() {
-    if (!tokenLogin?.nativeAuthToken) {
+    const {
+      remainingParams: { impersonate }
+    } = parseNavigationParams(['impersonate']);
+
+    if (!tokenLogin?.nativeAuthToken || impersonate) {
       return;
     }
 


### PR DESCRIPTION
### Issue
Impersonate no longer works on web wallet

### Root cause
Impersonated address is changed to the previous address, because the nativeAuth token is not changed

### Fix
Skip nativeAuth token address check durning impersonate process

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
