### PR TITLE
Updated default chainID to empty string instead of `-1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Updated default chainID to empty string instead of -1](https://github.com/multiversx/mx-sdk-dapp/pull/1192)
 - [Fixed infinite loop in `parseMultiEsdtTransferData`](https://github.com/multiversx/mx-sdk-dapp/pull/1191)
 - [Added extensible icons to certain components](https://github.com/multiversx/mx-sdk-dapp/pull/1188)
 

--- a/src/reduxStore/slices/networkConfigSlice.ts
+++ b/src/reduxStore/slices/networkConfigSlice.ts
@@ -35,7 +35,7 @@ export interface NetworkConfigStateType {
 
 const initialState: NetworkConfigStateType = {
   network: defaultNetwork,
-  chainID: '-1'
+  chainID: ''
 };
 
 export const networkConfigSlice = createSlice({


### PR DESCRIPTION
### Issue
Transactions signing fail on dapp refresh.

### Reproduce
- Go to Devnet Wallet (on firefox);
- Login with xPortal or Extension;
- Refresh;
- Send a transaction.

Actual Result: Transaction cancelled error appears
Expected Result: Transactions are signed and processing

### Root cause
`chainID` is set to `-1` by default. This causes the chainID check to pass as truthy in `waitForChainID` function and return an incorrect value.

Furthermore, the returned chainID will be different than the chainID of the signed transactions, so, those transactions will fail.

### Fix
Make the `chainID` `''` by default.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
