### PR TITLE
Allow custom environment as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Added support for custom environment in DappProvider](https://github.com/multiversx/mx-sdk-dapp/pull/1195)
+
 ## [[v2.33.3]](https://github.com/multiversx/mx-sdk-dapp/pull/1194)] - 2024-06-25
 
 - [ExperimentalWebviewProvider: full webkit support](https://github.com/multiversx/mx-sdk-dapp/pull/1193)

--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -7,19 +7,23 @@ import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
 import { isLoginSessionInvalidSelector } from 'reduxStore/selectors/loginInfoSelectors';
 import { setDappConfig } from 'reduxStore/slices';
 import { setLogoutRoute } from 'reduxStore/slices/loginInfoSlice';
-import { initializeNetworkConfig } from 'reduxStore/slices/networkConfigSlice';
+import {
+  defaultNetwork,
+  initializeNetworkConfig
+} from 'reduxStore/slices/networkConfigSlice';
+import { logout } from 'utils/logout';
 import {
   CustomNetworkType,
   DappConfigType,
+  IDappProvider,
   EnvironmentsEnum,
-  IDappProvider
-} from 'types';
-import { logout } from 'utils/logout';
+  NetworkType
+} from '../types';
 
 export interface UseAppInitializerPropsType {
   customNetworkConfig?: CustomNetworkType;
   externalProvider?: IDappProvider;
-  environment: EnvironmentsEnum;
+  environment: 'testnet' | 'mainnet' | 'devnet' | EnvironmentsEnum | string;
   dappConfig?: DappConfigType;
 }
 
@@ -46,15 +50,32 @@ export const useAppInitializer = ({
   async function initializeNetwork() {
     const fetchConfigFromServer = !customNetworkConfig?.skipFetchFromServer;
     const customNetworkApiAddress = customNetworkConfig?.apiAddress;
-    const fallbackConfig = fallbackNetworkConfigurations[environment] || {};
 
-    const localConfig = {
+    const isFoundEnv = environment in fallbackNetworkConfigurations;
+
+    const fallbackConfig: NetworkType | Record<string, string> = isFoundEnv
+      ? fallbackNetworkConfigurations[environment as EnvironmentsEnum]
+      : {};
+
+    const baseConfig = {
+      ...defaultNetwork,
       ...fallbackConfig,
       ...customNetworkConfig
     };
 
+    const localConfig: NetworkType = {
+      ...baseConfig,
+      walletConnectBridgeAddresses:
+        baseConfig.walletConnectBridgeAddresses || [],
+      walletConnectV2RelayAddresses:
+        'walletConnectV2RelayAddresses' in baseConfig
+          ? baseConfig.walletConnectV2RelayAddresses
+          : []
+    };
+
     if (fetchConfigFromServer) {
-      const fallbackApiAddress = fallbackConfig?.apiAddress;
+      const fallbackApiAddress =
+        'apiAddress' in fallbackConfig ? fallbackConfig.apiAddress : '';
 
       const serverConfig = await getServerConfiguration(
         customNetworkApiAddress || fallbackApiAddress

--- a/src/wrappers/DappProvider/DappProvider.tsx
+++ b/src/wrappers/DappProvider/DappProvider.tsx
@@ -6,9 +6,11 @@ import { setExternalProvider } from 'providers/accountProvider';
 import { ExperimentalWebviewProvider } from 'providers/experimentalWebViewProvider/ExperimentalWebviewProvider';
 import { DappCoreContext } from 'reduxStore/DappProviderContext';
 import { persistor, store } from 'reduxStore/store';
-import { CustomNetworkType, EnvironmentsEnum, IDappProvider } from 'types';
-import { DappConfigType } from 'types/dappConfig.types';
-import { AppInitializer } from 'wrappers/AppInitializer';
+import { CustomNetworkType, IDappProvider, DappConfigType } from '../../types';
+import {
+  AppInitializer,
+  UseAppInitializerPropsType
+} from './../../wrappers/AppInitializer';
 import { CustomComponents, CustomComponentsType } from './CustomComponents';
 
 export { DappConfigType };
@@ -24,7 +26,7 @@ export interface DappProviderPropsType {
   customNetworkConfig?: CustomNetworkType;
   externalProvider?: IDappProvider;
   //we need the strings for autocomplete suggestions
-  environment: 'testnet' | 'mainnet' | 'devnet' | EnvironmentsEnum;
+  environment: UseAppInitializerPropsType['environment'];
   customComponents?: CustomComponentsType;
   dappConfig?: DappConfigType;
 }
@@ -53,7 +55,7 @@ export const DappProvider = ({
       <PersistGate persistor={persistor} loading={null}>
         {() => (
           <AppInitializer
-            environment={environment as EnvironmentsEnum}
+            environment={environment}
             customNetworkConfig={customNetworkConfig}
             dappConfig={dappConfig}
           >


### PR DESCRIPTION
### Issue
sdk-dapp enforces a knwon environment

### Reproduce
Issue exists on version `2.33.3` of sdk-dapp.

### Root cause
There were only strict environments until sovereign shards

### Fix
Allow custom string as environment and get config from url

### Additional changes
Improve DappProvidere type imports

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
