### PR TITLE
Fix walletconnect settings for custom network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.33.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1197)] - 2024-06-27
+- [Fixed walletconnect settings for custom network](https://github.com/multiversx/mx-sdk-dapp/pull/1197)
+
 ## [[v2.33.4]](https://github.com/multiversx/mx-sdk-dapp/pull/1196)] - 2024-06-27
 - [Added support for custom environment in DappProvider](https://github.com/multiversx/mx-sdk-dapp/pull/1195)
 

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -41,7 +41,7 @@ export interface CustomNetworkType {
   apiAddress?: string;
   explorerAddress?: string;
   skipFetchFromServer?: boolean;
-  apiTimeout?: string;
+  apiTimeout?: string | number;
   walletConnectV2ProjectId?: string;
   walletConnectV2Options?: any;
 }

--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -70,7 +70,7 @@ export const useAppInitializer = ({
       walletConnectV2RelayAddresses:
         'walletConnectV2RelayAddresses' in baseConfig
           ? baseConfig.walletConnectV2RelayAddresses
-          : []
+          : ['wss://relay.walletconnect.com']
     };
 
     if (fetchConfigFromServer) {
@@ -83,7 +83,7 @@ export const useAppInitializer = ({
 
       if (serverConfig != null) {
         const apiConfig = {
-          ...fallbackConfig,
+          ...localConfig,
           ...serverConfig,
           ...customNetworkConfig
         };


### PR DESCRIPTION
### Issue
No walletconnect default settings for custom network

### Reproduce
Issue exists on version `2.33.4` of sdk-dapp.

### Root cause

### Fix
- add 'wss://relay.walletconnect.com' to fallbackConfig

### Additional changes
- fixed apiTimeout type to string | number

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
