### PR TITLE
2.33.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.33.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1197)] - 2024-06-27
+- [Fixed walletconnect settings for custom network](https://github.com/multiversx/mx-sdk-dapp/pull/1197)
+
 ## [[v2.33.4]](https://github.com/multiversx/mx-sdk-dapp/pull/1196)] - 2024-06-27
 - [Added support for custom environment in DappProvider](https://github.com/multiversx/mx-sdk-dapp/pull/1195)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.33.6]](https://github.com/multiversx/mx-sdk-dapp/pull/1200)] - 2024-07-03
+
 - [Update WalletConnect, disconnect default session (QR-code) on existing pairing](https://github.com/multiversx/mx-sdk-dapp/pull/1199)
 
 ## [[v2.33.5]](https://github.com/multiversx/mx-sdk-dapp/pull/1198)] - 2024-06-27

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.33.5",
+  "version": "2.33.6",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.33.4",
+  "version": "2.33.5",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -41,7 +41,7 @@ export interface CustomNetworkType {
   apiAddress?: string;
   explorerAddress?: string;
   skipFetchFromServer?: boolean;
-  apiTimeout?: string;
+  apiTimeout?: string | number;
   walletConnectV2ProjectId?: string;
   walletConnectV2Options?: any;
 }

--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -65,6 +65,7 @@ export const useAppInitializer = ({
 
     const localConfig: NetworkType = {
       ...baseConfig,
+      apiTimeout: String(baseConfig.apiTimeout),
       walletConnectBridgeAddresses:
         baseConfig.walletConnectBridgeAddresses || [],
       walletConnectV2RelayAddresses:
@@ -87,7 +88,12 @@ export const useAppInitializer = ({
           ...serverConfig,
           ...customNetworkConfig
         };
-        dispatch(initializeNetworkConfig(apiConfig));
+        dispatch(
+          initializeNetworkConfig({
+            ...apiConfig,
+            apiTimeout: String(apiConfig.apiTimeout)
+          })
+        );
         return;
       }
     }

--- a/src/wrappers/AppInitializer.tsx
+++ b/src/wrappers/AppInitializer.tsx
@@ -70,7 +70,7 @@ export const useAppInitializer = ({
       walletConnectV2RelayAddresses:
         'walletConnectV2RelayAddresses' in baseConfig
           ? baseConfig.walletConnectV2RelayAddresses
-          : []
+          : ['wss://relay.walletconnect.com']
     };
 
     if (fetchConfigFromServer) {
@@ -83,7 +83,7 @@ export const useAppInitializer = ({
 
       if (serverConfig != null) {
         const apiConfig = {
-          ...fallbackConfig,
+          ...localConfig,
           ...serverConfig,
           ...customNetworkConfig
         };


### PR DESCRIPTION
### Issue/Feature

- Updated @multiversx/sdk-wallet-connect-provider to 4.1.3 ( @walletconnect 2.13.3 )
- Avoid duplicated sign token messages on existing connections
- Disconnect from existing proposal ( QR code ) on click on existing connections

### Reproduce
Issue exists on version `2.` of sdk-dapp.

### Root cause

- Duplicated sign token messages on click on an existing connection

### Fix

- Disconnect from existing proposal ( QR code ) on click on existing connection

### Additional changes

### Contains breaking changes
[x] No
[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
