### PR TITLE
Removed cross shard rounds from polling interval calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.34.1]](https://github.com/multiversx/mx-sdk-dapp/pull/1206)] - 2024-07-18
+
+- [Removed cross shard rounds from polling interval calculations](https://github.com/multiversx/mx-sdk-dapp/pull/1205)
+
 ## [[v2.34.0]](https://github.com/multiversx/mx-sdk-dapp/pull/1204)] - 2024-07-17
 
 - [Added dynamic transaction polling based on network round duration](https://github.com/multiversx/mx-sdk-dapp/pull/1201)

--- a/src/hooks/transactions/useGetPollingInterval.ts
+++ b/src/hooks/transactions/useGetPollingInterval.ts
@@ -1,7 +1,4 @@
-import {
-  CROSS_SHARD_ROUNDS,
-  TRANSACTIONS_STATUS_POLLING_INTERVAL_MS
-} from 'constants/transactionStatus';
+import { TRANSACTIONS_STATUS_POLLING_INTERVAL_MS } from 'constants/transactionStatus';
 import { useSelector } from 'reduxStore/DappProviderContext';
 import { roundDurationSelectorSelector } from 'reduxStore/selectors';
 
@@ -12,5 +9,5 @@ export const useGetPollingInterval = () => {
     return TRANSACTIONS_STATUS_POLLING_INTERVAL_MS;
   }
 
-  return (roundDuration / 2) * CROSS_SHARD_ROUNDS;
+  return roundDuration;
 };


### PR DESCRIPTION
### Issue
Sovereign chains have one round, so, no need to add `CROSS_SHARD_ROUNDS` to the polling interval calculations.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
