### PR TITLE
Remove insufficient funds check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Allow signing transactions wihen user balance is zero](https://github.com/multiversx/mx-sdk-dapp/pull/1218)
 - [Added `matchPath` tests](https://github.com/multiversx/mx-sdk-dapp/pull/1216)
 
 

--- a/src/services/transactions/signTransactions.ts
+++ b/src/services/transactions/signTransactions.ts
@@ -1,7 +1,3 @@
-import BigNumber from 'bignumber.js';
-import { GAS_LIMIT } from 'constants/index';
-
-import { accountBalanceSelector } from 'reduxStore/selectors/accountInfoSelectors';
 import { chainIDSelector } from 'reduxStore/selectors/networkConfigSelectors';
 import {
   setNotificationModal,
@@ -16,41 +12,20 @@ import {
   SignTransactionsPropsType
 } from 'types';
 import { isGuardianTx } from 'utils/transactions/isGuardianTx';
-import { stringIsFloat } from 'utils/validation/stringIsFloat';
-import { calcTotalFee } from './utils';
 
 export async function signTransactions({
   transactions,
   callbackRoute,
-  minGasLimit = GAS_LIMIT,
   customTransactionInformation,
   transactionsDisplayInfo
 }: SignTransactionsPropsType): Promise<SendTransactionReturnType> {
   const appState = store.getState();
   const sessionId = Date.now().toString();
-  const accountBalance = accountBalanceSelector(appState);
   const storeChainId = chainIDSelector(appState);
 
   const transactionsPayload = Array.isArray(transactions)
     ? transactions
     : [transactions];
-  const bNtotalFee = calcTotalFee(transactionsPayload, minGasLimit);
-  const bNbalance = new BigNumber(
-    stringIsFloat(accountBalance) ? accountBalance : '0'
-  );
-  const hasSufficientFunds = bNbalance.minus(bNtotalFee).isGreaterThan(0);
-
-  if (!hasSufficientFunds) {
-    const notificationPayload = {
-      type: NotificationTypesEnum.warning,
-      iconClassName: 'text-warning',
-      title: 'Insufficient EGLD funds',
-      description: 'Current EGLD balance cannot cover the transaction fees.'
-    };
-
-    store.dispatch(setNotificationModal(notificationPayload));
-    return { error: 'insufficient funds', sessionId: null };
-  }
 
   const hasValidChainId = transactionsPayload?.every(
     (tx) => tx.getChainID().valueOf() === storeChainId.valueOf()

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -160,7 +160,7 @@ export interface SendBatchTransactionsPropsType {
 
 export interface SignTransactionsPropsType {
   transactions: Transaction[] | Transaction;
-  minGasLimit?: number;
+  minGasLimit?: number; // unused, will be removed in v3.0.0
   callbackRoute?: string;
   transactionsDisplayInfo: TransactionsDisplayInfoType;
   customTransactionInformation: CustomTransactionInformation;


### PR DESCRIPTION
### Issue
If a user wants to sign a transaction and has no balalance, signing does not work

### Reproduce
Issue exists on version `2.36.1` of sdk-dapp.

### Root cause
Transactions cannot be signed if main balance is 0

### Fix
Remove check for main balance over min gas limit


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
