### PR TITLE
Added ability to skip updating transaction nonces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Added ability to skip updating transaction nonces](https://github.com/multiversx/mx-sdk-dapp/pull/1223)
 
 ## [[v2.36.3]](https://github.com/multiversx/mx-sdk-dapp/pull/1222)] - 2024-08-06
 - [Prevent network update if there are no changes](https://github.com/multiversx/mx-sdk-dapp/pull/1220)

--- a/src/hooks/transactions/useSignTransactions.tsx
+++ b/src/hooks/transactions/useSignTransactions.tsx
@@ -308,7 +308,12 @@ export const useSignTransactions = () => {
 
     clearTransactionStatusMessage();
 
-    const { sessionId, transactions, callbackRoute } = transactionsToSign;
+    const {
+      sessionId,
+      transactions,
+      callbackRoute,
+      customTransactionInformation
+    } = transactionsToSign;
 
     if (!provider) {
       console.error(MISSING_PROVIDER_MESSAGE);
@@ -339,9 +344,10 @@ export const useSignTransactions = () => {
     try {
       const isSigningWithWebWallet = providerType === LoginMethodsEnum.wallet;
 
-      const transactionsWithIncrementalNonces = await setTransactionNonces(
-        transactions
-      );
+      const transactionsWithIncrementalNonces =
+        customTransactionInformation.skipUpdateNonces
+          ? transactions
+          : await setTransactionNonces(transactions);
 
       if (isSigningWithWebWallet) {
         return signWithWallet(

--- a/src/hooks/transactions/useSignTransactionsCommonData.tsx
+++ b/src/hooks/transactions/useSignTransactionsCommonData.tsx
@@ -42,9 +42,10 @@ export const useSignTransactionsCommonData = () => {
     const transactionsWithFixedNonce = transactionsToSign?.transactions ?? [];
 
     if (hasTransactionsToSign) {
-      const transactionsWithIncrementalNonces = await setTransactionNonces(
-        transactionsWithFixedNonce
-      );
+      const transactionsWithIncrementalNonces = transactionsToSign
+        ?.customTransactionInformation?.skipUpdateNonces
+        ? transactionsWithFixedNonce
+        : await setTransactionNonces(transactionsWithFixedNonce);
 
       setTransactions(transactionsWithIncrementalNonces);
     }

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -227,6 +227,10 @@ export interface CustomTransactionInformation {
   completedTransactionsDelay?: number;
   signWithoutSending: boolean;
   /**
+   * If true, transactions with lower nonces than the account nonce will not be updated with the correct nonce
+   */
+  skipUpdateNonces?: boolean;
+  /**
    * If true, the change guardian action will not trigger transaction version update
    */
   skipGuardian?: boolean;


### PR DESCRIPTION
### Feature
Added ability to skip updating transaction nonces

### Reproduce
Issue exists on version `2.36.3` of sdk-dapp.

### Root cause
If a soveregin shard has the same Chain ID as a testnet from fallbackNetworkConfigurations, nonces may be wrongly fetched from that network

### Fix
Allow skipping this mechanism


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
