### PR TITLE
Added method to clear existing window logins

### DIFF
--- a/src/hooks/login/helpers/clearInitiatedLogins.ts
+++ b/src/hooks/login/helpers/clearInitiatedLogins.ts
@@ -1,0 +1,23 @@
+import {
+  CrossWindowProvider,
+  MetamaskProxyProvider
+} from 'lib/sdkWebWalletCrossWindowProvider';
+import { LoginMethodsEnum } from 'types';
+
+export const clearInitiatedLogins = (props?: { skip: LoginMethodsEnum }) => {
+  Object.values(LoginMethodsEnum).forEach((method) => {
+    if (props?.skip && method === props.skip) {
+      return;
+    }
+    const crossWindowProvider = CrossWindowProvider.getInstance();
+    if (crossWindowProvider.isInitialized()) {
+      crossWindowProvider.dispose();
+    }
+    const metamaskProvider = MetamaskProxyProvider.getInstance();
+    if (metamaskProvider.isInitialized()) {
+      metamaskProvider.dispose();
+    }
+  });
+
+  return null;
+};

--- a/src/hooks/login/helpers/index.ts
+++ b/src/hooks/login/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './clearInitiatedLogins';

--- a/src/hooks/login/useCrossWindowLogin.ts
+++ b/src/hooks/login/useCrossWindowLogin.ts
@@ -18,6 +18,7 @@ import { getLatestNonce } from 'utils/account/getLatestNonce';
 import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { optionalRedirect } from 'utils/internal';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
+import { clearInitiatedLogins } from './helpers';
 import { useLoginService } from './useLoginService';
 
 export type UseCrossWindowLoginReturnType = [
@@ -50,6 +51,10 @@ export const useCrossWindowLogin = ({
     if (isLoggedIn) {
       throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
     }
+
+    clearInitiatedLogins({
+      skip: LoginMethodsEnum.crossWindow
+    });
 
     setIsLoading(true);
     const isSuccessfullyInitialized: boolean =

--- a/src/hooks/login/useExtensionLogin.ts
+++ b/src/hooks/login/useExtensionLogin.ts
@@ -15,6 +15,7 @@ import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { optionalRedirect } from 'utils/internal';
 import { addOriginToLocationPath } from 'utils/window';
 import { getDefaultCallbackUrl } from 'utils/window';
+import { clearInitiatedLogins } from './helpers';
 import { useLoginService } from './useLoginService';
 
 export type UseExtensionLoginReturnType = [
@@ -41,6 +42,8 @@ export const useExtensionLogin = ({
     if (isLoggedIn) {
       throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
     }
+
+    clearInitiatedLogins();
 
     setIsLoading(true);
     const provider: ExtensionProvider = ExtensionProvider.getInstance();

--- a/src/hooks/login/useLedgerLogin.ts
+++ b/src/hooks/login/useLedgerLogin.ts
@@ -19,6 +19,7 @@ import {
   OnProviderLoginType
 } from '../../types';
 import { getIsLoggedIn } from '../../utils';
+import { clearInitiatedLogins } from './helpers';
 import { useAddressScreens } from './useAddressScreens';
 import { useLoginService } from './useLoginService';
 const failInitializeErrorText = 'Check if the MultiversX App is open on Ledger';
@@ -275,6 +276,8 @@ export const useLedgerLogin = ({
     if (isLoggedIn) {
       throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
     }
+
+    clearInitiatedLogins();
 
     setError('');
 

--- a/src/hooks/login/useMetamaskLogin.ts
+++ b/src/hooks/login/useMetamaskLogin.ts
@@ -15,6 +15,7 @@ import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { optionalRedirect } from 'utils/internal';
 import { addOriginToLocationPath } from 'utils/window';
 import { getDefaultCallbackUrl } from 'utils/window';
+import { clearInitiatedLogins } from './helpers';
 import { useLoginService } from './useLoginService';
 
 export type UseMetamaskLoginReturnType = [
@@ -41,6 +42,8 @@ export const useMetamaskLogin = ({
     if (isLoggedIn) {
       throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
     }
+
+    clearInitiatedLogins();
 
     setIsLoading(true);
     const provider: MetamaskProvider = MetamaskProvider.getInstance();

--- a/src/hooks/login/useMetamaskProxyLogin.ts
+++ b/src/hooks/login/useMetamaskProxyLogin.ts
@@ -16,6 +16,7 @@ import {
 import { getLatestNonce } from 'utils/account/getLatestNonce';
 import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
+import { clearInitiatedLogins } from './helpers';
 import { useLoginService } from './useLoginService';
 
 export type UseMetamaskProxyLoginReturnType = [
@@ -45,6 +46,10 @@ export const useMetamaskProxyLogin = ({
     if (isLoggedIn) {
       throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
     }
+
+    clearInitiatedLogins({
+      skip: LoginMethodsEnum.metamaskProxy
+    });
 
     setIsLoading(true);
     const provider = MetamaskProxyProvider.getInstance();

--- a/src/hooks/login/useOperaLogin.ts
+++ b/src/hooks/login/useOperaLogin.ts
@@ -15,6 +15,7 @@ import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { optionalRedirect } from 'utils/internal';
 import { getDefaultCallbackUrl } from 'utils/window';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
+import { clearInitiatedLogins } from './helpers';
 import { useLoginService } from './useLoginService';
 
 export type UseOperaLoginReturnType = [
@@ -41,6 +42,8 @@ export const useOperaLogin = ({
     if (isLoggedIn) {
       throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
     }
+
+    clearInitiatedLogins();
 
     setIsLoading(true);
     const provider: OperaProvider = OperaProvider.getInstance();

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -31,6 +31,7 @@ import {
   LoginHookGenericStateType,
   OnProviderLoginType
 } from '../../types/login.types';
+import { clearInitiatedLogins } from './helpers';
 import { useLoginService } from './useLoginService';
 
 export enum WalletConnectV2Error {
@@ -284,6 +285,8 @@ export const useWalletConnectV2Login = ({
   };
 
   async function initiateLogin(loginProvider = true) {
+    clearInitiatedLogins();
+
     const chainId = await waitForChainID({ maxRetries: 15 });
 
     if (!chainId) {


### PR DESCRIPTION
### Issue
User is able to login with 2 providers

### Reproduce
Issue exists on version `2.38.5` of sdk-dapp.

1. Click on cross window wallet or Metamask proxy
2. Do not perform login
3. Click on Extension login
4. dApp loggs in
5. Continue login from point 1
6. => double login error

### Root cause
Window is not closed

### Fix
Call new dispose method on providers before performing new login

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
