### PR TITLE
Make metamask sign with sign screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Updated metamask sign screens to use ledger sign screens](https://github.com/multiversx/mx-sdk-dapp/pull/1243)
+
 ## [[v2.38.6]](https://github.com/multiversx/mx-sdk-dapp/pull/1242)] - 2024-08-23
 - [Fixed double login with cross-window or metamask](https://github.com/multiversx/mx-sdk-dapp/pull/1241)
 

--- a/src/UI/SignTransactionsModals/SignTransactionsModals.tsx
+++ b/src/UI/SignTransactionsModals/SignTransactionsModals.tsx
@@ -7,9 +7,9 @@ import { ConfirmationScreen, DeviceConfirmationScreen } from './components';
 import { SignWithCrossWindowWalletModal } from './SignWithCrossWindowWalletModal';
 import { SignWithExtensionModal } from './SignWithExtensionModal';
 import { SignWithExtraModal } from './SignWithExtraModal';
-import { SignWithMetamaskProxyModal } from './SignWithMetamaskProxyModal';
 import { SignWithLedgerModal } from './SignWithLedgerModal';
 import { SignWithMetamaskModal } from './SignWithMetamaskModal';
+import { SignWithMetamaskProxyModal } from './SignWithMetamaskProxyModal';
 import { SignWithOperaModal } from './SignWithOperaModal';
 import { SignWithWalletConnectModal } from './SignWithWalletConnectModal';
 import {
@@ -76,7 +76,7 @@ export const SignTransactionsModals = ({
     case LoginMethodsEnum.extension:
       return renderScreen({ Screen: ConfirmScreens.Extension });
     case LoginMethodsEnum.metamask:
-      return renderScreen({ Screen: ConfirmScreens.Metamask });
+      return renderScreen({ Screen: ConfirmScreens.Metamask, isDevice: true });
     case LoginMethodsEnum.opera:
       return renderScreen({ Screen: ConfirmScreens.Opera });
     case LoginMethodsEnum.crossWindow:

--- a/src/UI/SignTransactionsModals/SignWithMetamaskModal/SignWithMetamaskModal.tsx
+++ b/src/UI/SignTransactionsModals/SignWithMetamaskModal/SignWithMetamaskModal.tsx
@@ -1,23 +1,12 @@
 import React from 'react';
 import { SignModalPropsType } from 'types';
-
-import {
-  SignWaitingScreenModal,
-  SignWaitingScreenModalPropsType
-} from '../components';
+import { SignWithDeviceModal } from '../SignWithDeviceModal';
 
 export const SignWithMetamaskModal = (props: SignModalPropsType) => {
-  const description = props.error
-    ? props.error
-    : props.transactions?.length > 1
-    ? 'Check your Metamask to sign the transactions'
-    : 'Check your Metamask to sign the transaction';
-
-  const waitingScreenProps: SignWaitingScreenModalPropsType = {
-    ...props,
-    description,
-    title: 'Confirm on Metamask Wallet'
-  };
-
-  return <SignWaitingScreenModal {...waitingScreenProps} />;
+  return (
+    <SignWithDeviceModal
+      {...props}
+      title={props.title || 'Confirm on Metamask'}
+    />
+  );
 };


### PR DESCRIPTION
### Feature
Display transactions signed by metamask one by one

### Reproduce
Issue exists on version `2.` of sdk-dapp.

### Root cause
Metamask does not offer transaction details

### Fix
Use sdk-dapp sign screens same as for ledger

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
