### PR TITLE
Fixed websocket connection is not closed on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Fixed websocket connection is not closed on logout](https://github.com/multiversx/mx-sdk-dapp/pull/1248)
+- [Fixed websocket connection is not closed on logout](https://github.com/multiversx/mx-sdk-dapp/pull/1250)
 - [Upgrade sdk-dapp-utils, webview-provider, metamask-proxy-provider and cross-window-provider packages](https://github.com/multiversx/mx-sdk-dapp/pull/1247)
 
 ## [[v2.38.8]](https://github.com/multiversx/mx-sdk-dapp/pull/1246)] - 2024-08-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed websocket connection is not closed on logout](https://github.com/multiversx/mx-sdk-dapp/pull/1248)
 - [Upgrade sdk-dapp-utils, webview-provider, metamask-proxy-provider and cross-window-provider packages](https://github.com/multiversx/mx-sdk-dapp/pull/1247)
 
 ## [[v2.38.8]](https://github.com/multiversx/mx-sdk-dapp/pull/1246)] - 2024-08-29

--- a/src/hooks/websocketListener/useInitializeWebsocketConnection.tsx
+++ b/src/hooks/websocketListener/useInitializeWebsocketConnection.tsx
@@ -23,17 +23,15 @@ const DISCONNECT = 'disconnect';
 export function useInitializeWebsocketConnection() {
   const messageTimeout = useRef<NodeJS.Timeout | null>(null);
   const batchTimeout = useRef<NodeJS.Timeout | null>(null);
-
   const { address } = useGetAccount();
-
   const dispatch = useDispatch();
-
   const { network } = useGetNetworkConfig();
 
   const handleMessageReceived = (message: string) => {
     if (messageTimeout.current) {
       clearTimeout(messageTimeout.current);
     }
+
     messageTimeout.current = setTimeout(() => {
       dispatch(setWebsocketEvent(message));
     }, MESSAGE_DELAY);
@@ -43,14 +41,29 @@ export function useInitializeWebsocketConnection() {
     if (batchTimeout.current) {
       clearTimeout(batchTimeout.current);
     }
+
     batchTimeout.current = setTimeout(() => {
       dispatch(setWebsocketBatchEvent(data));
     }, MESSAGE_DELAY);
   };
 
+  const unsubscribeWS = () => {
+    websocketConnection.current?.close();
+    websocketConnection.current = null;
+    websocketConnection.status = WebsocketConnectionStatusEnum.NOT_INITIALIZED;
+
+    if (messageTimeout.current) {
+      clearTimeout(messageTimeout.current);
+    }
+  };
+
   const initializeWebsocketConnection = useCallback(
     retryMultipleTimes(
       async () => {
+        if (!address) {
+          return;
+        }
+
         // If there are many components that use this hook, the initialize method is triggered many times.
         // To avoid multiple connections to the same endpoint, we have to guard the initialization before the logic started
         websocketConnection.status = WebsocketConnectionStatusEnum.PENDING;
@@ -82,11 +95,18 @@ export function useInitializeWebsocketConnection() {
         });
 
         websocketConnection.current.on(DISCONNECT, () => {
-          console.warn('Websocket disconnected. Trying to reconnect...');
-          setTimeout(() => {
-            console.log('Websocket reconnecting...');
-            websocketConnection.current?.connect();
-          }, RETRY_INTERVAL);
+          if (address) {
+            // Make sure we are still logged in before retrying to connect to the websocket
+            console.warn('Websocket disconnected. Trying to reconnect...');
+
+            setTimeout(() => {
+              if (address) {
+                // Make sure we are still logged in when the timeout is finished
+                console.log('Websocket reconnecting...');
+                websocketConnection.current?.connect();
+              }
+            }, RETRY_INTERVAL);
+          }
         });
       },
       {
@@ -105,17 +125,18 @@ export function useInitializeWebsocketConnection() {
       !websocketConnection.current?.active
     ) {
       initializeWebsocketConnection();
+      return;
+    }
+
+    if (!address) {
+      // Close the websocket connection when we are not logged in
+      unsubscribeWS();
     }
   }, [address, initializeWebsocketConnection]);
 
   useEffect(() => {
     return () => {
-      websocketConnection.current?.close();
-      websocketConnection.status =
-        WebsocketConnectionStatusEnum.NOT_INITIALIZED;
-      if (messageTimeout.current) {
-        clearTimeout(messageTimeout.current);
-      }
+      unsubscribeWS();
     };
   }, []);
 }


### PR DESCRIPTION
### Issue
After logout and login to another account/address, the websocket event no longer works.

### Root cause
Websocket connection still exists for the previous logged int account.

### Fix
Close connection on logout and reconnect only when logged in.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
