### PR TITLE
remove starts with erd check for valid addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v2.40.7]](https://github.com/multiversx/mx-sdk-dapp/pull/1267)] - 2024-09-23
+- [Remove hardcoded "erd" check when validating an address](https://github.com/multiversx/mx-sdk-dapp/pull/1267)
+
 
 ## [[v2.40.6]](https://github.com/multiversx/mx-sdk-dapp/pull/1266)] - 2024-09-20
 - [Update passkey provider in order to fix passkey login](https://github.com/multiversx/mx-sdk-dapp/pull/1266)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "2.40.6",
+  "version": "2.40.7",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/utils/account/addressIsValid.ts
+++ b/src/utils/account/addressIsValid.ts
@@ -11,9 +11,7 @@ function canTransformToPublicKey(address: string) {
 
 export function addressIsValid(destinationAddress: string) {
   const isValidBach =
-    destinationAddress?.startsWith('erd') &&
-    destinationAddress.length === 62 &&
-    /^\w+$/.test(destinationAddress);
+    destinationAddress.length === 62 && /^\w+$/.test(destinationAddress);
 
   return isValidBach && canTransformToPublicKey(destinationAddress);
 }


### PR DESCRIPTION
### Issue
When checking for valid address we check if it statrs with "erd" this does not allow other HRP's

### Reproduce
Issue exists on version `2.40.6` of sdk-dapp.

### Root cause
Hardcoded "erd" check 

### Fix
Remove the hardcoded "erd" since converting the string to Address object should be sufficient

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
