### PR TITLE
Fixed axios interceptor concurrent calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed axios interceptor concurrent calls](https://github.com/multiversx/mx-sdk-dapp/pull/1278)
+
 ## [[v2.40.10](https://github.com/multiversx/mx-sdk-dapp/pull/1277)] - 2024-10-04
 
 - [Update WalletConnect Provider](https://github.com/multiversx/mx-sdk-dapp/pull/1276)


### PR DESCRIPTION
### Issue
Dapp is receiving the token before the interceptor is set

### Root cause
When the native token is set in useAxiosInterceptorContext, both api call from dapp is triggered and the interceptor request and leads to a concurrency issue

### Fix
Remove  native token dependency for injecting the interceptor

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
