### PR TITLE
Fix axios interceptors concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed axios interceptor concurrent calls](https://github.com/multiversx/mx-sdk-dapp/pull/1278)
+
 ## [[v2.40.10](https://github.com/multiversx/mx-sdk-dapp/pull/1277)] - 2024-10-04
 
 - [Update WalletConnect Provider](https://github.com/multiversx/mx-sdk-dapp/pull/1276)


### PR DESCRIPTION
### Issue
Dapp is receiving the native auth token before the interceptor is set

### Root cause
When the native token is set in `useAxiosInterceptorContext`, API call from dapp is triggered before interceptor is set and leads to a concurrency issue

### Fix
Remove native token useEffect dependency for injecting the interceptor

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
