### PR TITLE
update skip method to clear only initiated login state

### DIFF
--- a/src/hooks/login/helpers/clearInitiatedLogins.ts
+++ b/src/hooks/login/helpers/clearInitiatedLogins.ts
@@ -2,9 +2,11 @@ import { CrossWindowProvider } from 'lib/sdkWebWalletCrossWindowProvider';
 import { IframeProvider } from 'lib/sdkWebWalletIframeProvider';
 import { LoginMethodsEnum } from 'types';
 
-export const clearInitiatedLogins = (props?: { skip: LoginMethodsEnum }) => {
+export const clearInitiatedLogins = (props?: {
+  intiatedLogin: LoginMethodsEnum;
+}) => {
   Object.values(LoginMethodsEnum).forEach((method) => {
-    if (props?.skip && method === props.skip) {
+    if (props?.intiatedLogin && method !== props.intiatedLogin) {
       return;
     }
     const crossWindowProvider = CrossWindowProvider.getInstance();

--- a/src/hooks/login/useCrossWindowLogin.ts
+++ b/src/hooks/login/useCrossWindowLogin.ts
@@ -53,7 +53,7 @@ export const useCrossWindowLogin = ({
     }
 
     clearInitiatedLogins({
-      skip: LoginMethodsEnum.crossWindow
+      intiatedLogin: LoginMethodsEnum.crossWindow
     });
 
     setIsLoading(true);

--- a/src/hooks/login/useIframeLogin.ts
+++ b/src/hooks/login/useIframeLogin.ts
@@ -50,7 +50,7 @@ export const useIframeLogin = ({
     }
 
     clearInitiatedLogins({
-      skip: LoginMethodsEnum.iframe
+      intiatedLogin: LoginMethodsEnum.iframe
     });
 
     setIsLoading(true);


### PR DESCRIPTION
### Issue
When logging into another with Web Wallet cross window multiple tabs where opened  if another wallet tab is already open
### Reproduce
Open a wallet tab and in parallel open a dapp and try login with web wallet cross window
Issue exists on version `2.40.11` of sdk-dapp.

### Root cause
When the provider is already initialised the clearInitiatedLogins tries to close all other logins providers sessions instead of clearing the cross window session 
### Fix
Change clearInitiatedLogins to only clear cross window provider sesion
### Additional changes
No
### Contains breaking changes
No
- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
