### PR TITLE
Fix clear initiated login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix clear initiated login](https://github.com/multiversx/mx-sdk-dapp/pull/1301)
+
 ## [[v3.0.8](https://github.com/multiversx/mx-sdk-dapp/pull/1299)] - 2024-11-04
 
 - [Update skip method to clear only initiated login state](https://github.com/multiversx/mx-sdk-dapp/pull/1298)
-
 - [Updated Iframe provider imports](https://github.com/multiversx/mx-sdk-dapp/pull/1297)
 - [Fixed Iframe provider reload](https://github.com/multiversx/mx-sdk-dapp/pull/1295)
 

--- a/src/hooks/login/helpers/clearInitiatedLogins.ts
+++ b/src/hooks/login/helpers/clearInitiatedLogins.ts
@@ -3,19 +3,29 @@ import { IframeProvider } from 'lib/sdkWebWalletIframeProvider';
 import { LoginMethodsEnum } from 'types';
 
 export const clearInitiatedLogins = (props?: {
-  intiatedLoginMethod: LoginMethodsEnum;
+  skipLoginMethod: LoginMethodsEnum;
 }) => {
   Object.values(LoginMethodsEnum).forEach((method) => {
-    if (props?.intiatedLoginMethod && method !== props.intiatedLoginMethod) {
+    if (method === props?.skipLoginMethod) {
       return;
     }
-    const crossWindowProvider = CrossWindowProvider.getInstance();
-    if (crossWindowProvider.isInitialized()) {
-      crossWindowProvider.dispose();
-    }
-    const iframeProvider = IframeProvider.getInstance();
-    if (iframeProvider.isInitialized()) {
-      iframeProvider.dispose();
+    switch (method) {
+      case LoginMethodsEnum.crossWindow: {
+        const crossWindowProvider = CrossWindowProvider.getInstance();
+        if (crossWindowProvider.isInitialized()) {
+          crossWindowProvider.dispose();
+        }
+        break;
+      }
+      case LoginMethodsEnum.iframe: {
+        const iframeProvider = IframeProvider.getInstance();
+        if (iframeProvider.isInitialized()) {
+          iframeProvider.dispose();
+        }
+        break;
+      }
+      default:
+        break;
     }
   });
 

--- a/src/hooks/login/useCrossWindowLogin.ts
+++ b/src/hooks/login/useCrossWindowLogin.ts
@@ -53,7 +53,7 @@ export const useCrossWindowLogin = ({
     }
 
     clearInitiatedLogins({
-      intiatedLoginMethod: LoginMethodsEnum.crossWindow
+      skipLoginMethod: LoginMethodsEnum.crossWindow
     });
 
     setIsLoading(true);

--- a/src/hooks/login/useIframeLogin.ts
+++ b/src/hooks/login/useIframeLogin.ts
@@ -50,7 +50,7 @@ export const useIframeLogin = ({
     }
 
     clearInitiatedLogins({
-      intiatedLoginMethod: LoginMethodsEnum.iframe
+      skipLoginMethod: LoginMethodsEnum.iframe
     });
 
     setIsLoading(true);


### PR DESCRIPTION
### Issue
When logging into another with Web Wallet cross window multiple tabs where opened if another wallet tab is already open
### Reproduce
Open a wallet tab and in parallel open a dapp and try login with web wallet cross window
Issue exists on version 3.0.8 of sdk-dapp.

### Root cause
When the provider is already initialised the clearInitiatedLogins tries to close all other logins providers sessions instead of clearing the cross window session
### Fix
Change clearInitiatedLogins to only clear current login method provider session
### Additional changes
No
### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
