### PR TITLE
Fixed "stringIsFloat" issue for huge decimal numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed "stringIsFloat" issue for huge decimal numbers](https://github.com/multiversx/mx-sdk-dapp/pull/1309)
+
 ## [[v3.0.11](https://github.com/multiversx/mx-sdk-dapp/pull/1308)] - 2024-11-19
 
 - [Updated transaction data decode functions](https://github.com/multiversx/mx-sdk-dapp/pull/1307)

--- a/src/utils/validation/stringIsFloat.ts
+++ b/src/utils/validation/stringIsFloat.ts
@@ -15,6 +15,16 @@ export const stringIsFloat = (amount: string) => {
   // eslint-disable-next-line
   let [wholes, decimals] = amount.split('.');
   if (decimals) {
+    const areAllNumbers = decimals
+      .split('')
+      .every((digit) => !isNaN(parseInt(digit)));
+
+    BigNumber.set({
+      DECIMAL_PLACES: areAllNumbers
+        ? decimals.length
+        : BigNumber.config().DECIMAL_PLACES
+    });
+
     while (decimals.charAt(decimals.length - 1) === ZERO) {
       decimals = decimals.slice(0, -1);
     }

--- a/src/utils/validation/tests/stringIsFloat.test.ts
+++ b/src/utils/validation/tests/stringIsFloat.test.ts
@@ -54,4 +54,7 @@ describe('stringIsFloat tests', () => {
   it('denies caret separation', () => {
     expect(stringIsFloat(Infinity as any)).toBe(false);
   });
+  it('allows large numbers', () => {
+    expect(stringIsFloat('0.0000000011231723871623178236182376123')).toBe(true);
+  });
 });

--- a/src/utils/validation/tests/stringIsFloat.test.ts
+++ b/src/utils/validation/tests/stringIsFloat.test.ts
@@ -4,57 +4,86 @@ describe('stringIsFloat tests', () => {
   it('rejects undefined', () => {
     expect(stringIsFloat(undefined as any)).toBe(false);
   });
+
   it('rejects object', () => {
     expect(stringIsFloat({} as any)).toBe(false);
   });
+
   it('rejects null', () => {
     expect(stringIsFloat(null as any)).toBe(false);
   });
+
   it('allows valid numbers', () => {
     expect(stringIsFloat('1')).toBe(true);
   });
+
   it('allows decimal numbers with zeros', () => {
     expect(stringIsFloat('0.1')).toBe(true);
     expect(stringIsFloat('0.001')).toBe(true);
   });
+
   it('allows large decimal places', () => {
     expect(stringIsFloat('999999999999999999999.123456789012345678')).toBe(
       true
     );
+
     expect(stringIsFloat('0.111111111111111111')).toBe(true);
   });
+
   it('allows trailing 0', () => {
     expect(stringIsFloat('0.10')).toBe(true);
     expect(stringIsFloat('10')).toBe(true);
   });
+
   it('denies negative numbers', () => {
     expect(stringIsFloat('-1')).toBe(false);
   });
+
   it('denies explicit positive', () => {
     expect(stringIsFloat('+1')).toBe(false);
   });
+
   it('denies leading 0', () => {
     expect(stringIsFloat('01')).toBe(false);
   });
+
   it('denies string', () => {
     expect(stringIsFloat('null')).toBe(false);
   });
+
   it('denies hexadecimal', () => {
     expect(stringIsFloat('0x2')).toBe(false);
   });
+
   it('denies exponential', () => {
     expect(stringIsFloat('1e2')).toBe(false);
   });
+
   it('denies caret separation', () => {
     expect(stringIsFloat('100_200')).toBe(false);
   });
+
   it('denies NaN', () => {
     expect(stringIsFloat(NaN as any)).toBe(false);
   });
+
   it('denies caret separation', () => {
     expect(stringIsFloat(Infinity as any)).toBe(false);
   });
+
   it('allows large numbers', () => {
     expect(stringIsFloat('0.0000000011231723871623178236182376123')).toBe(true);
+  });
+
+  it('allows large numbers with single comma', () => {
+    expect(stringIsFloat('0,0000000011231723871623178236182376123')).toBe(
+      false
+    );
+  });
+
+  it('allows large numbers with multiple commas', () => {
+    expect(stringIsFloat('0,0000000011231723,87,162.317,8236182376123')).toBe(
+      false
+    );
   });
 });

--- a/src/utils/validation/tests/stringIsFloat.test.ts
+++ b/src/utils/validation/tests/stringIsFloat.test.ts
@@ -86,4 +86,12 @@ describe('stringIsFloat tests', () => {
       false
     );
   });
+
+  it('denies numbers with special characters', () => {
+    expect(stringIsFloat('-0.12323')).toBe(false);
+    expect(stringIsFloat('-0,2230323...')).toBe(false);
+    expect(stringIsFloat('0.1123@tsd123')).toBe(false);
+    expect(stringIsFloat('0.11aaaa233')).toBe(false);
+    expect(stringIsFloat('0,1233oooosdd123')).toBe(false);
+  });
 });

--- a/src/utils/validation/tests/stringIsFloat.test.ts
+++ b/src/utils/validation/tests/stringIsFloat.test.ts
@@ -75,13 +75,13 @@ describe('stringIsFloat tests', () => {
     expect(stringIsFloat('0.0000000011231723871623178236182376123')).toBe(true);
   });
 
-  it('allows large numbers with single comma', () => {
+  it('denies numbers with single comma', () => {
     expect(stringIsFloat('0,0000000011231723871623178236182376123')).toBe(
       false
     );
   });
 
-  it('allows large numbers with multiple commas', () => {
+  it('denies numbers with multiple commas', () => {
     expect(stringIsFloat('0,0000000011231723,87,162.317,8236182376123')).toBe(
       false
     );


### PR DESCRIPTION
### Issue
Checking if a string is a floating number would wrongfully return `false` for amounts with many decimals points, such as `0.0000000011231723871623178236182376123`, that exceeds the default decimal places of `BigNumber.js` set at `20`. 

Issue exists on version `3.0.11` of `mx-sdk-dapp`.

### Fix
Added a `BigNumber.set` method to set the decimal places to whatever the decimals' length is. Otherwise, keep it to the default one.

### Contains breaking changes
- [x] No
- [ ] Yes

### Updated CHANGELOG
- [ ] No
- [x] Yes

### Testing
- [x] User testing
- [x] Unit tests
