### PR TITLE
Fixed BigNumber.js scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed BigNumber configuration, scoped to a function level in "stringIsFloat"](https://github.com/multiversx/mx-sdk-dapp/pull/1312)
+
 ## [[v3.0.12](https://github.com/multiversx/mx-sdk-dapp/pull/1310)] - 2024-11-20
 
 - [Fixed "stringIsFloat" issue for huge decimal numbers](https://github.com/multiversx/mx-sdk-dapp/pull/1309)

--- a/src/utils/validation/stringIsFloat.ts
+++ b/src/utils/validation/stringIsFloat.ts
@@ -14,12 +14,14 @@ export const stringIsFloat = (amount: string) => {
 
   // eslint-disable-next-line
   let [wholes, decimals] = amount.split('.');
+  const LocalBigNumber = BigNumber.clone();
+
   if (decimals) {
     const areAllNumbers = decimals
       .split('')
       .every((digit) => !isNaN(parseInt(digit)));
 
-    BigNumber.set({
+    LocalBigNumber.set({
       DECIMAL_PLACES: areAllNumbers
         ? decimals.length
         : BigNumber.config().DECIMAL_PLACES
@@ -30,6 +32,10 @@ export const stringIsFloat = (amount: string) => {
     }
   }
   const number = decimals ? [wholes, decimals].join('.') : wholes;
-  const bNparsed = new BigNumber(number);
-  return bNparsed.toString(10) === number && bNparsed.comparedTo(0) >= 0;
+  const bNparsed = LocalBigNumber(number);
+
+  const output =
+    bNparsed.toString(10) === number && bNparsed.comparedTo(0) >= 0;
+
+  return output;
 };


### PR DESCRIPTION
### Issue
The `BigNumber` configuration was not properly cleaned up in the `stringIsFloat` helper function, thus overwriting the configuration in other helper functions too, creating a race condition.

### Reproduce
Issue exists on version `3.0.12` of sdk-dapp.

### Root cause
The cause was the `BigNumber.set` method called globally in the `stringIsFloat` helper function.

### Fix
Create a clone of the `BigNumber` instance and scope it locally, and only change the settings at a local function level.

### Contains breaking changes
- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
