### PR TITLE
Updated default metamaskSnapWalletAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Updated default metamaskSnapWalletAddress](https://github.com/multiversx/mx-sdk-dapp/pull/1314)
+
 ## [[v3.0.13](https://github.com/multiversx/mx-sdk-dapp/pull/1313)] - 2024-11-25
 
 - [Fixed BigNumber configuration, scoped to a function level in "stringIsFloat"](https://github.com/multiversx/mx-sdk-dapp/pull/1312)

--- a/src/constants/network.ts
+++ b/src/constants/network.ts
@@ -20,7 +20,7 @@ export const fallbackNetworkConfigurations: Record<
     xAliasAddress: 'https://devnet.xalias.com',
     apiAddress: 'https://devnet-api.multiversx.com',
     explorerAddress: 'http://devnet-explorer.multiversx.com',
-    metamaskSnapWalletAddress: 'https://devnet-snap-wallet.multiversx.com',
+    metamaskSnapWalletAddress: 'https://devnet-iframe-wallet.multiversx.com',
     apiTimeout: '4000',
     roundDuration: 6000
   },
@@ -40,7 +40,7 @@ export const fallbackNetworkConfigurations: Record<
     xAliasAddress: 'https://testnet.xalias.com',
     apiAddress: 'https://testnet-api.multiversx.com',
     explorerAddress: 'http://testnet-explorer.multiversx.com',
-    metamaskSnapWalletAddress: 'https://testnet-snap-wallet.multiversx.com',
+    metamaskSnapWalletAddress: 'https://testnet-iframe-wallet.multiversx.com',
     apiTimeout: '4000',
     roundDuration: 6000
   },
@@ -60,7 +60,7 @@ export const fallbackNetworkConfigurations: Record<
     xAliasAddress: 'https://xalias.com',
     apiAddress: 'https://api.multiversx.com',
     explorerAddress: 'https://explorer.multiversx.com',
-    metamaskSnapWalletAddress: 'https://snap-wallet.multiversx.com',
+    metamaskSnapWalletAddress: 'https://iframe-wallet.multiversx.com',
     apiTimeout: '4000',
     roundDuration: 6000
   }


### PR DESCRIPTION
### Issue/Feature

- Updated default metamaskSnapWalletAddress

### Reproduce

Issue exists on version `2.` of sdk-dapp.

### Root cause

### Fix

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
