### PR TITLE
Updated get network config from API logic

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn install
 
       - name: Run tests
-        run: yarn test
+        run: yarn test --silent
 
       - name: Build project
         run: yarn build

--- a/.github/workflows/pre-merge-unit-tests.yml
+++ b/.github/workflows/pre-merge-unit-tests.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Build
         run: yarn build
       - name: Run unit tests
-        run: yarn test
+        run: yarn test --silent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[v3.0.17](https://github.com/multiversx/mx-sdk-dapp/pull/1320)] - 2024-11-26
-
 - [Updated get network config from API logic](https://github.com/multiversx/mx-sdk-dapp/pull/1319)
 
 ## [[v3.0.16](https://github.com/multiversx/mx-sdk-dapp/pull/1318)] - 2024-11-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v3.0.17](https://github.com/multiversx/mx-sdk-dapp/pull/1320)] - 2024-11-26
+
 - [Updated get network config from API logic](https://github.com/multiversx/mx-sdk-dapp/pull/1319)
 
 ## [[v3.0.16](https://github.com/multiversx/mx-sdk-dapp/pull/1318)] - 2024-11-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- [Updated get network config from API logic](https://github.com/multiversx/mx-sdk-dapp/pull/1319)
+
 ## [[v3.0.16](https://github.com/multiversx/mx-sdk-dapp/pull/1318)] - 2024-11-26
 
 - [Updated provider initializer to use useGetAccountFromApi](https://github.com/multiversx/mx-sdk-dapp/pull/1317)
-
-## [Unreleased]
-
-- [Updated get network config from API logic](https://github.com/multiversx/mx-sdk-dapp/pull/1317)
 
 ## [[v3.0.15](https://github.com/multiversx/mx-sdk-dapp/pull/1316)] - 2024-11-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Updated get network config from API logic](https://github.com/multiversx/mx-sdk-dapp/pull/1317)
+
 ## [[v3.0.15](https://github.com/multiversx/mx-sdk-dapp/pull/1316)] - 2024-11-25
 
 - [Added transaction data decoder](https://github.com/multiversx/mx-sdk-dapp/pull/1311)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "3.0.17-alpha.0",
+  "version": "3.0.17",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "3.0.17",
+  "version": "3.0.16",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "3.0.15",
+  "version": "3.0.16-alpha.0",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -60,6 +60,11 @@ import {
   getIframeProvider
 } from './helpers';
 import { useSetLedgerProvider } from './hooks';
+import {
+  DEVNET_CHAIN_ID,
+  MAINNET_CHAIN_ID,
+  TESTNET_CHAIN_ID
+} from '../../constants';
 
 let initalizingLedger = false;
 
@@ -116,6 +121,16 @@ export function ProviderInitializer() {
   }, [ledgerAccount, isLoggedIn, ledgerData]);
 
   async function refreshNetworkConfig() {
+    const shouldGetConfig =
+      !network.chainId ||
+      ![DEVNET_CHAIN_ID, TESTNET_CHAIN_ID, MAINNET_CHAIN_ID].includes(
+        network.chainId
+      );
+
+    if (!shouldGetConfig) {
+      return;
+    }
+
     try {
       const networkConfig = await getNetworkConfigFromApi();
       const hasDifferentNetworkConfig =

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -124,6 +124,8 @@ export function ProviderInitializer() {
     setLedgerAccountInfo();
   }, [ledgerAccount, isLoggedIn, ledgerData]);
 
+  // We need to get the roundDuration for networks that do not support websocket (e.g. sovereign)
+  // The round duration is used for polling interval
   async function refreshNetworkConfig() {
     const shouldGetConfig =
       !network.chainId ||

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef } from 'react';
 import { getNetworkConfigFromApi, useGetAccountFromApi } from 'apiCalls';
+import {
+  DEVNET_CHAIN_ID,
+  MAINNET_CHAIN_ID,
+  TESTNET_CHAIN_ID
+} from 'constants/index';
 import { useLoginService } from 'hooks/login/useLoginService';
 import { useWalletConnectV2Login } from 'hooks/login/useWalletConnectV2Login';
 import { useWebViewLogin } from 'hooks/login/useWebViewLogin';
@@ -59,11 +64,6 @@ import {
   getIframeProvider
 } from './helpers';
 import { useSetLedgerProvider } from './hooks';
-import {
-  DEVNET_CHAIN_ID,
-  MAINNET_CHAIN_ID,
-  TESTNET_CHAIN_ID
-} from '../../constants';
 
 let initalizingLedger = false;
 

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -127,11 +127,15 @@ export function ProviderInitializer() {
   // We need to get the roundDuration for networks that do not support websocket (e.g. sovereign)
   // The round duration is used for polling interval
   async function refreshNetworkConfig() {
-    const shouldGetConfig =
-      !network.chainId ||
+    const needsRoundDurationForPollingInterval =
+      network.chainId &&
       ![DEVNET_CHAIN_ID, TESTNET_CHAIN_ID, MAINNET_CHAIN_ID].includes(
         network.chainId
-      );
+      ) &&
+      !network.roundDuration;
+
+    const shouldGetConfig =
+      !network.chainId || needsRoundDurationForPollingInterval;
 
     if (!shouldGetConfig) {
       return;


### PR DESCRIPTION
The network config is fetched from `/dapp/config` regardless. We need to fetch the config only if the `chainId` is missing or if we need the `roundDuration`. The `roundDuration` is used in (sovereign) chains that do not have websocket and rely on regular polling intervals to refresh the data.