### PR TITLE
Fixed cross window page reload on internal logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed cross window page reload on internal logout](https://github.com/multiversx/mx-sdk-dapp/pull/1350)
+
 ## [[v3.1.4](https://github.com/multiversx/mx-sdk-dapp/pull/1349)] - 2024-12-16
 
 - [Fixed logout doesn't work when `shouldBroadcastLogoutAcrossTabs` is `false`](https://github.com/multiversx/mx-sdk-dapp/pull/1348)

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -1,3 +1,4 @@
+import { safeWindow } from 'lib/sdkDappUtils';
 import { CrossWindowProvider } from 'lib/sdkWebWalletCrossWindowProvider';
 import { getAccountProvider, getProviderType } from 'providers';
 import { logoutAction } from 'reduxStore/commonActions';
@@ -70,13 +71,17 @@ export async function logout(
 
   const url = addOriginToLocationPath(callbackUrl);
   const location = getWindowLocation();
-  const callbackPathname = new URL(decodeURIComponent(url)).pathname;
+  const { pathname: callbackPathname, origin: callbackOrigin } = new URL(
+    decodeURIComponent(url)
+  );
 
   // Prevent page redirect if the logout callbackURL is equal to the current URL
   // or if is wallet provider
+  // or if we are in a child tab (redirects via window.assign cause automatic tab close)
   if (
     matchPath(location.pathname, callbackPathname) ||
-    (isWalletProvider && isProviderInitialised)
+    (isWalletProvider && isProviderInitialised) ||
+    (safeWindow?.opener && callbackOrigin === safeWindow?.origin)
   ) {
     preventRedirects();
   }


### PR DESCRIPTION
### Issue
Automatic reply with cancelled is triggered when Ledger is disconncted, but previously logged in.

### Reproduce
- Login in a DApp via web wallet cross window with ledger;
- Disconnect Ledger device;
- Try to sign a transaction
- Automatic Transaction cancelled is triggered

### Root cause
When the provider is not initialised, but the address is present in sdk-dapp, an internal logout is triggered, which makes the page redirect to unlockRoute. Page redirects or reloads cause the cross-window tab to close and trigger automatic transaction cancel.

### Fix
Prevent redirects when we are in cross window and the redirect origin is the same as the current origin.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
