### PR TITLE
Added Optional Receiver Trimming Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Added optional receiver trimming option](https://github.com/multiversx/mx-sdk-dapp/pull/1367)
+
 ## [[v3.2.0](https://github.com/multiversx/mx-sdk-dapp/pull/1366)] - 2025-01-28
 
 - [Added support for relayed transactions](https://github.com/multiversx/mx-sdk-dapp/pull/1365)

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmReceiver/ConfirmReceiver.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmReceiver/ConfirmReceiver.tsx
@@ -120,20 +120,16 @@ const ConfirmReceiverComponent = ({
             </span>
           )}
 
-          {shouldTrimReceiver && (
-            <CopyButton
-              text={receiver}
-              className={styles?.receiverCopy}
-              copyIcon={customCopyIcon}
-            />
-          )}
+          <CopyButton
+            text={receiver}
+            className={styles?.receiverCopy}
+            copyIcon={customCopyIcon}
+          />
 
           <ExplorerLink
             page={`/${ACCOUNTS_ENDPOINT}/${receiver}`}
             customExplorerIcon={customExplorerIcon}
-            className={classNames(styles?.receiverExternal, {
-              [styles?.large]: !shouldTrimReceiver
-            })}
+            className={styles?.receiverExternal}
           />
         </div>
       )}

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmReceiver/ConfirmReceiver.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmReceiver/ConfirmReceiver.tsx
@@ -3,6 +3,7 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import BigNumber from 'bignumber.js';
+import classNames from 'classnames';
 
 import { useGetAccountFromApi, ACCOUNTS_ENDPOINT } from 'apiCalls';
 import MultiversXIconSimple from 'assets/icons/mvx-icon-simple.svg';
@@ -25,6 +26,7 @@ export interface ConfirmReceiverPropsType extends WithStylesImportType {
   receiver: string;
   receiverUsername?: string;
   scamReport: string | null;
+  shouldTrimReceiver?: boolean;
 }
 
 const ConfirmReceiverComponent = ({
@@ -35,6 +37,7 @@ const ConfirmReceiverComponent = ({
   receiverUsername,
   customCopyIcon,
   scamReport,
+  shouldTrimReceiver = true,
   styles
 }: ConfirmReceiverPropsType) => {
   const isSmartContract = isContract(receiver);
@@ -53,7 +56,8 @@ const ConfirmReceiverComponent = ({
     receiver && Boolean(foundReceiverUsername) && !usernameAccountError
   );
 
-  const defaultReceiverLabel = isAmountZero ? 'To interact with' : 'To';
+  const defaultReceiverLabel =
+    isAmountZero && isSmartContract ? 'To interact with' : 'To';
 
   return (
     <div className={styles?.receiver}>
@@ -85,10 +89,16 @@ const ConfirmReceiverComponent = ({
         </div>
       ) : (
         <div
-          className={styles?.receiverWrapper}
           data-testid={DataTestIdsEnum.confirmReceiver}
+          className={classNames(styles?.receiverWrapper, {
+            [styles?.unwrappable]: shouldTrimReceiver
+          })}
         >
-          <Trim text={receiver} className={styles?.receiverTrim} />
+          {shouldTrimReceiver ? (
+            <Trim text={receiver} className={styles?.receiverTrim} />
+          ) : (
+            <div className={styles?.receiverText}>{receiver}</div>
+          )}
 
           {hasUsername && !isSmartContract && (
             <span className={styles?.receiverData}>
@@ -110,16 +120,20 @@ const ConfirmReceiverComponent = ({
             </span>
           )}
 
-          <CopyButton
-            text={receiver}
-            className={styles?.receiverCopy}
-            copyIcon={customCopyIcon}
-          />
+          {shouldTrimReceiver && (
+            <CopyButton
+              text={receiver}
+              className={styles?.receiverCopy}
+              copyIcon={customCopyIcon}
+            />
+          )}
 
           <ExplorerLink
             page={`/${ACCOUNTS_ENDPOINT}/${receiver}`}
-            className={styles?.receiverExternal}
             customExplorerIcon={customExplorerIcon}
+            className={classNames(styles?.receiverExternal, {
+              [styles?.large]: !shouldTrimReceiver
+            })}
           />
         </div>
       )}

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmReceiver/confirmReceiverStyles.scss
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmReceiver/confirmReceiverStyles.scss
@@ -44,8 +44,17 @@
     display: flex;
     align-items: center;
     line-height: 1;
-    white-space: nowrap;
     gap: 8px;
+
+    &.unwrappable {
+      white-space: nowrap;
+    }
+
+    .receiverText {
+      font-size: 16px;
+      word-break: break-all;
+      line-height: 1.25;
+    }
 
     .receiverData {
       color: #737373;
@@ -69,6 +78,14 @@
     .receiverExternal {
       margin: 0;
       max-height: 1rem;
+
+      &.large {
+        max-height: 16px;
+
+        svg {
+          height: 16px;
+        }
+      }
 
       &:hover * {
         color: #0ac2ae !important;

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmReceiver/confirmReceiverStyles.scss
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmReceiver/confirmReceiverStyles.scss
@@ -51,7 +51,6 @@
     }
 
     .receiverText {
-      font-size: 16px;
       word-break: break-all;
       line-height: 1.25;
     }
@@ -78,14 +77,6 @@
     .receiverExternal {
       margin: 0;
       max-height: 1rem;
-
-      &.large {
-        max-height: 16px;
-
-        svg {
-          height: 16px;
-        }
-      }
 
       &:hover * {
         color: #0ac2ae !important;


### PR DESCRIPTION
### Feature
Add the possibility to optionally not trim the receiver inside the `ConfirmReceiver` components. This is useful for the situations where you don't want to show a trimmed address in case of sending to a scam address by mistake.

### Reproduce
Feature doesn't exist on version `3.2.0` of `sdk-dapp`.

### Contains breaking changes
- [x] No
- [ ] Yes

### Updated CHANGELOG
- [ ] No
- [x] Yes

### Testing
- [x] User testing
- [ ] Unit tests
