### PR TITLE
Fixed wallet tab reopens immediately after close/cancel during cross window login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed wallet tab reopens immediately after close/cancel during cross window login](https://github.com/multiversx/mx-sdk-dapp/pull/1372)
+
 ## [[v3.2.2](https://github.com/multiversx/mx-sdk-dapp/pull/1371)] - 2025-02-04
 
 - [Fixed walletconnect init fails after cross window login attempt](https://github.com/multiversx/mx-sdk-dapp/pull/1370)

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@multiversx/sdk-opera-provider": "1.0.0-alpha.1",
     "@multiversx/sdk-passkey-provider": "2.0.0",
     "@multiversx/sdk-wallet-connect-provider": "5.0.2",
-    "@multiversx/sdk-web-wallet-cross-window-provider": "2.0.5",
+    "@multiversx/sdk-web-wallet-cross-window-provider": "2.0.6",
     "@multiversx/sdk-web-wallet-iframe-provider": "2.0.1",
     "@multiversx/sdk-web-wallet-provider": "4.1.0",
     "@multiversx/sdk-webview-provider": "2.0.3",

--- a/src/hooks/login/useCrossWindowLogin.ts
+++ b/src/hooks/login/useCrossWindowLogin.ts
@@ -109,7 +109,7 @@ export const useCrossWindowLogin = ({
       if (!address) {
         setIsLoading(false);
         // Reset the `CrossWindowProvider` if the login failed
-        await CrossWindowProvider.getInstance().dispose();
+        CrossWindowProvider.getInstance().onDestroy();
         console.warn('Login cancelled.');
         return;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2545,10 +2545,10 @@
     "@walletconnect/utils" "2.17.3"
     bech32 "1.1.4"
 
-"@multiversx/sdk-web-wallet-cross-window-provider@2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-cross-window-provider/-/sdk-web-wallet-cross-window-provider-2.0.5.tgz#1494c5d4b6482b9a3050a7f901eff246572480bc"
-  integrity sha512-wm110f4Ra9z7sqGSluMgQx5dDRLeSHwbjCg9nocxWZ1V76Cc6XDpzD9se1SEClJ1vT2wl3E7Q1L+NYi4COfCHQ==
+"@multiversx/sdk-web-wallet-cross-window-provider@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-cross-window-provider/-/sdk-web-wallet-cross-window-provider-2.0.6.tgz#5c2360d506189ca9c42ee9ee729ea18e00e2b02c"
+  integrity sha512-+BdLjLrLN83eqir7NHzs7e9Yb6Bpkp9ThlklvRzBFhmh4/vZhuXWtFHEgOhuXM8zGGpjNYQ0TRIVO17x+NjfEA==
   dependencies:
     qs "6.11.2"
 
@@ -8342,9 +8342,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.73:
-  version "1.5.91"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.91.tgz#cf5567f6853062493242133aefd4dc8dc8440abd"
-  integrity sha512-sNSHHyq048PFmZY4S90ax61q+gLCs0X0YmcOII9wG9S2XwbVr+h4VW2wWhnbp/Eys3cCwTxVF292W3qPaxIapQ==
+  version "1.5.93"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.93.tgz#6fae820ac8bb772a841aa67fce5389e6c6da7ba2"
+  integrity sha512-M+29jTcfNNoR9NV7la4SwUqzWAxEwnc7ThA5e1m6LRSotmpfpCpLcIfgtSCVL+MllNLgAyM/5ru86iMRemPzDQ==
 
 element-resize-detector@^1.2.2:
   version "1.2.4"
@@ -8456,9 +8456,9 @@ enhanced-resolve@^4.5.0:
     tapable "^1.0.0"
 
 enhanced-resolve@^5.17.1:
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz#91eb1db193896b9801251eeff1c6980278b1e404"
-  integrity sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==
+  version "5.18.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz#728ab082f8b7b6836de51f1637aab5d3b9568faf"
+  integrity sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -10827,11 +10827,11 @@ is-binary-path@~2.1.0:
     binary-extensions "^2.0.0"
 
 is-boolean-object@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.2.1.tgz#c20d0c654be05da4fbc23c562635c019e93daf89"
-  integrity sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz#7067f47709809a393c71ff5bb3e135d8a9215d9e"
+  integrity sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==
   dependencies:
-    call-bound "^1.0.2"
+    call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
 is-buffer@^1.1.5:
@@ -13414,9 +13414,9 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-inspect@^1.13.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.3.tgz#f14c183de51130243d6d18ae149375ff50ea488a"
-  integrity sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
+  integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
 
 object-is@^1.1.5:
   version "1.1.6"
@@ -15315,9 +15315,9 @@ sass@1.56.1:
     source-map-js ">=0.6.2 <2.0.0"
 
 sass@^1.49.0:
-  version "1.83.4"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.83.4.tgz#5ccf60f43eb61eeec300b780b8dcb85f16eec6d1"
-  integrity sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==
+  version "1.84.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.84.0.tgz#da9154cbccb2d2eac7a9486091b6d9ba93ef5bad"
+  integrity sha512-XDAbhEPJRxi7H0SxrnOpiXFQoUJHwkR2u3Zc4el+fK/Tt5Hpzw5kkQ59qVDfvdaUq6gCrEZIbySFBM2T9DNKHg==
   dependencies:
     chokidar "^4.0.0"
     immutable "^5.0.2"
@@ -16360,9 +16360,9 @@ terser@^4.1.2, terser@^4.6.3:
     source-map-support "~0.5.12"
 
 terser@^5.3.4, terser@^5.31.1:
-  version "5.37.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.37.0.tgz#38aa66d1cfc43d0638fab54e43ff8a4f72a21ba3"
-  integrity sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==
+  version "5.38.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.38.0.tgz#df742bb69ee556c29650e926ff154d116f4ccf79"
+  integrity sha512-a4GD5R1TjEeuCT6ZRiYMHmIf7okbCPEuhQET8bczV6FrQMMlFXA1n+G0KKjdlFCm3TEHV77GxfZB3vZSUQGFpg==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"


### PR DESCRIPTION
### Issue

After initiating cross window login, if the user closes the newly opened wallet tab, the tab reopens immediately

### Reproduce

1. Go to xexchange and click Connect -> Web wallet login
2. Wallet tab opens -> Close it

Result: Wallet tab reopens immediately

### Root cause

When the login is cancelled/fails, `dispose` method is called from `CrossWindowProvider` which triggers the web wallet tab to reopen

### Fix

Add `onDestroy` method in `CrossWindowProvider` and `WindowManager` to only reset the `isInitialized` flag and remove the `CrossWindowProvider` instance.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
