### PR TITLE
Fix: update metamask addon link to use new Chrome Web Store domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed metamask addon link to use new Chrome Web Store domain](https://github.com/multiversx/mx-sdk-dapp/pull/1374)
+
 ## [[v3.2.3](https://github.com/multiversx/mx-sdk-dapp/pull/1373)] - 2025-02-06
 
 - [Fixed wallet tab reopens immediately after close/cancel during cross window login](https://github.com/multiversx/mx-sdk-dapp/pull/1372)
@@ -19,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Added optional receiver trimming option](https://github.com/multiversx/mx-sdk-dapp/pull/1367)
 - [Added test badge on readme](https://github.com/multiversx/mx-sdk-dapp/pull/1369)
-
 
 ## [[v3.2.0](https://github.com/multiversx/mx-sdk-dapp/pull/1366)] - 2025-01-28
 

--- a/src/constants/extension.constants.ts
+++ b/src/constants/extension.constants.ts
@@ -5,7 +5,7 @@ export const CHROME_EXTENSION_LINK =
   'https://chrome.google.com/webstore/detail/multiversx-defi-wallet/dngmlblcodfobpdpecaadgfbcggfjfnm';
 
 export const FIREFOX_METAMASK_ADDON_LINK =
-  'https://addons.mozilla.org/en-US/firefox/addon/metamask-flask/';
+  'https://addons.mozilla.org/en-US/firefox/addon/ether-metamask';
 
 export const CHROME_METAMASK_EXTENSION_LINK =
-  'https://chromewebstore.google.com/detail/metamask-flask-developmen/ljfoeinjpaedjfecbmggjgodbgkmjkjk';
+  'https://chromewebstore.google.com/detail/metamask/nkbihfbeogaeaoehlefnkodbefgpgknn?hl=en';


### PR DESCRIPTION
### Issue
Metamask links point to wrong web store extensions

### Fix

The Chrome Web Store has migrated from chrome.google.com/webstore to chromewebstore.google.com. This commit updates the Metamask extension link to use the new domain.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
