### PR TITLE
Unconfirmed Guardian Change Toast

### DIFF
--- a/src/UI/GuardianWarningToast/GuardianWarningToast.tsx
+++ b/src/UI/GuardianWarningToast/GuardianWarningToast.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { faWarning } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import { WithStylesImportType } from 'hocs/useStyles';
+import { withStyles } from 'hocs/withStyles';
+
+export const GuardianWarningToastComponent = ({
+  styles
+}: WithStylesImportType) => (
+  <div className={styles?.guardianWarningToast}>
+    <div className={styles?.guardianWarningToastHeading}>
+      <FontAwesomeIcon
+        icon={faWarning}
+        className={styles?.guardianWarningToastHeadingIcon}
+      />
+
+      <div className={styles?.guardianWarningToastHeadingText}>
+        Account at risk!
+      </div>
+    </div>
+
+    <div className={styles?.guardianWarningToastDescription}>
+      Your account has an unconfirmed guardian change, which could be caused by
+      a possible breach! Be cautious before making any transaction.
+    </div>
+  </div>
+);
+
+export const GuardianWarningToast = withStyles(GuardianWarningToastComponent, {
+  ssrStyles: () =>
+    import('UI/GuardianWarningToast/guardianWarningToastStyles.scss'),
+  clientStyles: () =>
+    require('UI/GuardianWarningToast/guardianWarningToastStyles.scss').default
+});

--- a/src/UI/GuardianWarningToast/guardianWarningToastStyles.scss
+++ b/src/UI/GuardianWarningToast/guardianWarningToastStyles.scss
@@ -1,0 +1,24 @@
+@use '../../assets/sass/variables/variables.scss';
+
+.guardian-warning-toast {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .guardian-warning-toast-heading {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    .guardian-warning-toast-heading-icon {
+      color: variables.$danger;
+      font-size: 20px;
+    }
+
+    .guardian-warning-toast-heading-text {
+      color: variables.$danger;
+      font-size: 16px;
+    }
+  }
+}

--- a/src/UI/GuardianWarningToast/index.ts
+++ b/src/UI/GuardianWarningToast/index.ts
@@ -1,0 +1,1 @@
+export * from './GuardianWarningToast';

--- a/src/UI/index.ts
+++ b/src/UI/index.ts
@@ -21,6 +21,7 @@ export * from './TransactionsToastList/components';
 export * from './Trim';
 export * from './Loader';
 export * from './Pagination';
+export * from './GuardianWarningToast';
 export * from './UsdValue';
 export * from './walletConnect/WalletConnectLoginButton';
 export * from './walletConnect/WalletConnectLoginContainer';

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+
 import { getNetworkConfigFromApi, useGetAccountFromApi } from 'apiCalls';
 import {
   DEVNET_CHAIN_ID,
@@ -15,6 +16,7 @@ import {
 import { loginAction } from 'reduxStore/commonActions';
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
 import {
+  accountSelector,
   addressSelector,
   ledgerAccountSelector
 } from 'reduxStore/selectors/accountInfoSelectors';
@@ -52,8 +54,8 @@ import {
   refreshAccount
 } from 'utils/account';
 import { parseNavigationParams } from 'utils/parseNavigationParams';
-
 import { isContract } from 'utils/smartContracts';
+
 import {
   getOperaProvider,
   getCrossWindowProvider,
@@ -63,15 +65,16 @@ import {
   getMetamaskProvider,
   getIframeProvider
 } from './helpers';
-import { useSetLedgerProvider } from './hooks';
+import { useGuardianChangeToast, useSetLedgerProvider } from './hooks';
 
 let initalizingLedger = false;
 
 export function ProviderInitializer() {
+  const { loginMethod, iframeLoginType } = useSelector(loginInfoSelector);
+
   const network = useSelector(networkSelector);
   const walletAddress = useSelector(walletAddressSelector);
   const walletConnectLogin = useSelector(walletConnectLoginSelector);
-  const { loginMethod, iframeLoginType } = useSelector(loginInfoSelector);
   const walletLogin = useSelector(walletLoginSelector);
   const address = useSelector(addressSelector);
   const ledgerAccount = useSelector(ledgerAccountSelector);
@@ -79,7 +82,10 @@ export function ProviderInitializer() {
   const isLoggedIn = useSelector(isLoggedInSelector);
   const chainID = useSelector(chainIDSelector);
   const tokenLogin = useSelector(tokenLoginSelector);
+  const userAccount = useSelector(accountSelector);
+  const handleGuardianWarningToast = useGuardianChangeToast();
   const nativeAuthConfig = tokenLogin?.nativeAuthConfig;
+
   const loginService = useLoginService(
     nativeAuthConfig ? nativeAuthConfig : false
   );
@@ -123,6 +129,12 @@ export function ProviderInitializer() {
     // prevent balance double fetching by handling ledgerAccount data separately
     setLedgerAccountInfo();
   }, [ledgerAccount, isLoggedIn, ledgerData]);
+
+  useEffect(() => {
+    if (isLoggedIn && userAccount.address) {
+      handleGuardianWarningToast(userAccount);
+    }
+  }, [isLoggedIn, userAccount]);
 
   // We need to get the roundDuration for networks that do not support websocket (e.g. sovereign)
   // The round duration is used for polling interval

--- a/src/components/ProviderInitializer/hooks/index.ts
+++ b/src/components/ProviderInitializer/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useSetLedgerProvider';
+export * from './useGuardianChangeToast';

--- a/src/components/ProviderInitializer/hooks/useGuardianChangeToast.tsx
+++ b/src/components/ProviderInitializer/hooks/useGuardianChangeToast.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { faWarning } from '@fortawesome/free-solid-svg-icons';
+
+import { AccountType } from 'types';
+import { GuardianWarningToast } from 'UI';
+import { addNewCustomToast, storage } from 'utils';
+import { localStorageKeys } from 'utils/storage/local';
+
+const DAYS_TO_SHOW_AGAIN_AFTER_DISMISSAL = 3;
+const SECONDS_IN_A_DAY = 24 * 60 * 60;
+
+export const useGuardianChangeToast = () => {
+  const guardianBreachToastDismissTimestamp = storage.local.getItem(
+    localStorageKeys.guardianBreachToastDismissTimestamp
+  );
+
+  const handleToastDismissal = () => {
+    const daysAsSeconds = SECONDS_IN_A_DAY * DAYS_TO_SHOW_AGAIN_AFTER_DISMISSAL;
+    const currentTimestamp = Date.now();
+
+    storage.local.setItem({
+      key: localStorageKeys.guardianBreachToastDismissTimestamp,
+      data: currentTimestamp,
+      expires: currentTimestamp + daysAsSeconds
+    });
+  };
+
+  const insertGuardianWarningToast = () => {
+    addNewCustomToast({
+      toastId: 'guardianUnconfirmedChangeWarning',
+      title: 'Account at risk!',
+      component: () => <GuardianWarningToast />,
+      icon: faWarning,
+      onClose: handleToastDismissal
+    });
+  };
+
+  const handleGuardianWarningToast = (userAccount: AccountType) => {
+    const isGuardedAccountPendingChange =
+      userAccount.isGuarded &&
+      userAccount.activeGuardianAddress &&
+      userAccount.pendingGuardianAddress;
+
+    if (isGuardedAccountPendingChange && !guardianBreachToastDismissTimestamp) {
+      insertGuardianWarningToast();
+      return;
+    }
+  };
+
+  return handleGuardianWarningToast;
+};

--- a/src/utils/storage/local.ts
+++ b/src/utils/storage/local.ts
@@ -2,7 +2,9 @@ import { getUnixTimestamp } from 'utils/dateTime';
 
 export const localStorageKeys = {
   loginExpiresAt: 'sdk-dapp-login-expires-at',
-  logoutEvent: 'sdk-dapp-logout-event'
+  logoutEvent: 'sdk-dapp-logout-event',
+  guardianBreachToastDismissTimestamp:
+    'sdk-dapp-guardian-breach-toast-dismiss-timestamp'
 } as const;
 
 type LocalValueType = keyof typeof localStorageKeys;


### PR DESCRIPTION
### Issue/Feature
Added a toast, with the purpose of warning the user that there has been an unconfirmed guardian change on his account. The toast is dismissible but it'll keep popping up after each three days if no action is taken, otherwise it'll basically appear on every authentication event. Feature doesn't exist on version `3.2.3` of `sdk-dapp`.


### Contains breaking changes
- [x] No
- [ ] Yes

### Updated CHANGELOG
- [ ] No
- [x] Yes

### Testing
- [x] User testing
- [ ] Unit tests
