### PR TITLE
Conditional price radios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [[v3.3.1](https://github.com/multiversx/mx-sdk-dapp/pull/1380)] - 2025-03-13
+- [Added conditional price radios visibility](https://github.com/multiversx/mx-sdk-dapp/pull/1381)
+
 ## [[v3.3.0](https://github.com/multiversx/mx-sdk-dapp/pull/1380)] - 2025-03-11
 - [Added gasPrice editing](https://github.com/multiversx/mx-sdk-dapp/pull/1377)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[v3.3.1](https://github.com/multiversx/mx-sdk-dapp/pull/1380)] - 2025-03-13
-- [Added conditional price radios visibility](https://github.com/multiversx/mx-sdk-dapp/pull/1381)
+## [[v3.3.1](https://github.com/multiversx/mx-sdk-dapp/pull/1387)] - 2025-03-13
+- [Added conditional price radios visibility](https://github.com/multiversx/mx-sdk-dapp/pull/1386)
 
 ## [[v3.3.0](https://github.com/multiversx/mx-sdk-dapp/pull/1380)] - 2025-03-11
 - [Added gasPrice editing](https://github.com/multiversx/mx-sdk-dapp/pull/1377)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmFee/ConfirmFee.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmFee/ConfirmFee.tsx
@@ -78,8 +78,12 @@ const ConfirmFeeComponent = ({
 
   const initialGasPrice = initialGasPriceInfo[nonce];
 
-  const fastPpu = gasStationMetadata?.[Number(shard)]?.fast;
-  const fasterPpu = gasStationMetadata?.[Number(shard)]?.faster;
+  const fastPpu = gasStationMetadata
+    ? gasStationMetadata[Number(shard)]?.fast
+    : 0;
+  const fasterPpu = gasStationMetadata
+    ? gasStationMetadata[Number(shard)]?.faster
+    : 0;
 
   const fastGasPrice = fastPpu
     ? recommendGasPrice({

--- a/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmFee/components/GasDetails/GasDetails.tsx
+++ b/src/UI/SignTransactionsModals/SignWithDeviceModal/components/components/ConfirmFee/components/GasDetails/GasDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { EMPTY_PPU } from 'constants/network';
 import { withStyles } from 'hocs/withStyles';
+import { useGetAccount } from 'hooks';
 import { useSelector } from 'reduxStore/DappProviderContext';
 import { networkConfigSelector } from 'reduxStore/selectors';
 
@@ -26,9 +27,10 @@ export const GasDetailsComponent = ({
 }: GasDetailsPropsType) => {
   const gasPrice = transaction.getGasPrice().valueOf().toString();
   const gasLimit = transaction.getGasLimit().valueOf().toString();
+  const { shard } = useGetAccount();
 
   const {
-    network: { egldLabel, ppuForGasPrice }
+    network: { egldLabel, gasStationMetadata }
   } = useSelector(networkConfigSelector);
 
   const formattedGasPrice = formatAmount({
@@ -42,7 +44,7 @@ export const GasDetailsComponent = ({
     updatePPU(Number(event.target.value) as ActiveLedgerTransactionType['ppu']);
   };
 
-  if (!ppuForGasPrice) {
+  if (!gasStationMetadata) {
     return null;
   }
 
@@ -53,11 +55,11 @@ export const GasDetailsComponent = ({
     },
     {
       label: 'Fast',
-      value: ppuForGasPrice.fast
+      value: gasStationMetadata[Number(shard)].fast
     },
     {
       label: 'Faster',
-      value: ppuForGasPrice.faster
+      value: gasStationMetadata[Number(shard)].faster
     }
   ];
 

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -17,10 +17,11 @@ export interface BaseNetworkType {
   roundDuration: number;
   metamaskSnapWalletAddress?: string;
   websocketUrl?: string;
-  ppuForGasPrice?: {
+  gasStationMetadata?: {
     fast: number;
     faster: number;
-  };
+    excellentJustLikeMoveBalance?: number;
+  }[];
 }
 
 export interface AccountInfoSliceNetworkType extends BaseNetworkType {


### PR DESCRIPTION
### Issue
In some cases, choosing fast price will output the same minimal price. Solution is to only show price editing options if the options increase the default transaction price.

### Reproduce
Tried to sign a transaction with a really small gas limit like 50,000

### Root cause
Recommend gas price function outputs minimal gas price

### Fix
Compare minimal price with the existing initial gas price and only show the radius if it is higher

### Additional changes
Upgrade to gasStationMetadata

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
