### PR TITLE
Fixed floating data field decode dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed floating data field decode dropdown](https://github.com/multiversx/mx-sdk-dapp/pull/1390)
 - [Updated address validation](https://github.com/multiversx/mx-sdk-dapp/pull/1389)
 - [Added conditional price radios visibility per radio button](https://github.com/multiversx/mx-sdk-dapp/pull/1388)
 

--- a/src/UI/TransactionData/TransactionDataStyles.scss
+++ b/src/UI/TransactionData/TransactionDataStyles.scss
@@ -1,22 +1,23 @@
-.transactionData {
+.transaction-data {
   display: flex;
   flex-direction: column;
   line-height: 1;
   gap: 8px;
 
-  .transactionDataLabel {
+  .transaction-data-label {
     align-items: center;
     color: #a3a3a3;
     display: flex;
+    position: relative;
     justify-content: space-between;
   }
 
-  .transactionDataValueWrapper {
+  .transaction-data-value-wrapper {
     border-radius: 8px;
     border: 1px solid #262626;
     padding: 4px;
 
-    .transactionDataValue {
+    .transaction-data-value {
       min-height: 60px;
       line-height: 1.25;
       max-height: 60px;
@@ -64,11 +65,11 @@
         background-color: transparent;
       }
 
-      .transactionDataValueText {
+      .transaction-data-value-text {
         flex: 1;
       }
 
-      .transactionDataValueCopy {
+      .transaction-data-value-copy {
         position: sticky;
         min-width: 1rem;
         max-width: 1rem;


### PR DESCRIPTION
### Issue
Styles were broken for the data field decode options dropdown. It was floating to the right of whatever element it first found with `position: relative`. Issue exists on `v3.3.1` of `sdk-dapp`.

### Contains breaking changes
- [x] No
- [ ] Yes

### Updated CHANGELOG
- [ ] No
- [x] Yes

### Testing
- [x] User testing
- [ ] Unit tests
