### PR TITLE
Support two cross-window wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v4.1.5](https://github.com/multiversx/mx-sdk-dapp/pull/1411)] - 2025-05-07
+
+- [Added support for two cross-window wallets](https://github.com/multiversx/mx-sdk-dapp/pull/1410)
+
 ## [[v4.1.4](https://github.com/multiversx/mx-sdk-dapp/pull/1409)] - 2025-05-07
 
 - [Added account cleanup on login](https://github.com/multiversx/mx-sdk-dapp/pull/1408)

--- a/src/components/ProviderInitializer/ProviderInitializer.tsx
+++ b/src/components/ProviderInitializer/ProviderInitializer.tsx
@@ -408,7 +408,7 @@ export function ProviderInitializer() {
     const address = await getAddress();
     const provider = await getCrossWindowProvider({
       address,
-      walletUrl: network.walletAddress
+      walletUrl: network.customWalletAddress ?? network.walletAddress
     });
     if (provider) {
       setAccountProvider(provider);

--- a/src/hooks/login/useCrossWindowLogin.ts
+++ b/src/hooks/login/useCrossWindowLogin.ts
@@ -7,6 +7,7 @@ import { setAccountProvider } from 'providers/accountProvider';
 import { loginAction } from 'reduxStore/commonActions';
 import { useDispatch, useSelector } from 'reduxStore/DappProviderContext';
 import { networkSelector } from 'reduxStore/selectors/networkConfigSelectors';
+import { setCustomWalletAddress } from 'reduxStore/slices';
 import { emptyAccount, setAccount, setAddress } from 'reduxStore/slices';
 import {
   InitiateLoginFunctionType,
@@ -62,6 +63,10 @@ export const useCrossWindowLogin = ({
     setIsLoading(true);
     const isSuccessfullyInitialized: boolean =
       await CrossWindowProvider.getInstance().init();
+
+    if (walletAddress) {
+      dispatch(setCustomWalletAddress(walletAddress));
+    }
 
     const provider: CrossWindowProvider =
       CrossWindowProvider.getInstance().setWalletUrl(

--- a/src/models/newTransaction.ts
+++ b/src/models/newTransaction.ts
@@ -22,11 +22,6 @@ export function newTransaction(rawTransaction: RawTransactionType) {
       ? { receiverUsername: rawTx.receiverUsername }
       : {}),
     ...(rawTx.relayer ? { relayer: new Address(rawTx.relayer) } : {}),
-    ...(rawTx.relayerSignature
-      ? {
-          relayerSignature: new Uint8Array(Buffer.from(rawTx.relayerSignature))
-        }
-      : {}),
     sender: new Address(rawTx.sender),
     ...(rawTx.senderUsername ? { senderUsername: rawTx.senderUsername } : {}),
     gasLimit: BigInt(rawTx.gasLimit.valueOf() ?? GAS_LIMIT),
@@ -36,6 +31,10 @@ export function newTransaction(rawTransaction: RawTransactionType) {
     ...(rawTx.options ? { options: rawTx.options } : {}),
     ...(rawTx.guardian ? { guardian: new Address(rawTx.guardian) } : {})
   });
+
+  if (rawTx.relayerSignature) {
+    transaction.relayerSignature = Buffer.from(rawTx.relayerSignature, 'hex');
+  }
 
   if (rawTx.guardianSignature) {
     transaction.guardianSignature = Buffer.from(rawTx.guardianSignature, 'hex');


### PR DESCRIPTION
### Issue
Using a custom `walletAddress` in `useCrossWindowLogin` does not persist for signing

### Reproduce
login like
```
  const [onInitiateDevnetLogin] = useCrossWindowLogin({
    callbackRoute: RouteNamesEnum.dashboard,
    nativeAuth,
    onLoginRedirect: () => {
      navigate(RouteNamesEnum.dashboard);
    },
    walletAddress: 'https://devnet-wallet.multiversx.com'
  });
```
does not persist the used `walletAddress`

### Root cause
not saved to store

### Fix
save in existing `customWalletAddress` that gets removed at logout

### Additional changes
Fixed `relayerAddress` econding

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
