### PR TITLE
Prevent calling `provider.logout()` if not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Prevent calling `provider.logout()` if not initialized](https://github.com/multiversx/mx-sdk-dapp/pull/1416)
+
 ## [[v4.1.7](https://github.com/multiversx/mx-sdk-dapp/pull/1415)] - 2025-05-12
 
 - [Added `apiAddress` option to getAccount](https://github.com/multiversx/mx-sdk-dapp/pull/1413)

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -87,7 +87,7 @@ export async function logout(
   }
 
   // We are already logged out, so we can redirect to the dapp
-  if (!address && !isProviderInitialised) {
+  if (!address) {
     return redirectToCallbackUrl({
       callbackUrl: url,
       onRedirect
@@ -97,7 +97,7 @@ export async function logout(
   try {
     store.dispatch(logoutAction());
 
-    if (isWalletProvider) {
+    if (isWalletProvider && isProviderInitialised) {
       // Allow redux store cleanup before redirect to web wallet
       return setTimeout(() => {
         provider.logout({ callbackUrl: url });
@@ -113,7 +113,9 @@ export async function logout(
       );
     }
 
-    await provider.logout({ callbackUrl: url });
+    if (isProviderInitialised) {
+      await provider.logout({ callbackUrl: url });
+    }
   } catch (err) {
     console.error('Logging out error:', err);
   } finally {


### PR DESCRIPTION
### Issue/Feature

There was an error when calling logout: 'Unable to perform logout with options. Provider is not initialized'

### Reproduce

Navigate to https://devnet-wallet.multiversx.com/logout multiple times (when logged in or not)

### Root cause

The logout logic doesn't check if the provider is initialized before calling `provider.logout()`, leading to errors when trying to logout with an uninitialized provider.

### Fix

Refactor logout logic to prevent calling `provider.logout()` if the provider is not initialized, ensuring safer logout behavior.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
