### PR TITLE
Add closeCallback in UnlockPanelManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Add closeCallback in UnlockPanelManager](https://github.com/multiversx/mx-sdk-dapp/pull/1425)
+
 ## [[5.0.0-alpha.0](https://github.com/multiversx/mx-sdk-dapp/pull/1421)] - 2025-05-20
 
 - [Edit project configs](https://github.com/multiversx/mx-sdk-dapp/pull/1423)
 - [Rename to sdk-dapp](https://github.com/multiversx/mx-sdk-dapp/pull/1420)
 
-----------------
+---
 
 - [Upgrade sdk-dapp-ui](https://github.com/multiversx/mx-sdk-dapp-core/pull/172)
 - [Fix walletConnect login issues](https://github.com/multiversx/mx-sdk-dapp-core/pull/171)
@@ -173,7 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [[v0.0.0]](https://github.com/multiversx/mx-sdk-dapp-core)] - 2024-04-17
 
----------------------
+---
 
 ## [[v4.1.8](https://github.com/multiversx/mx-sdk-dapp/pull/1418)] - 2025-05-20
 

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.ts
@@ -50,7 +50,6 @@ export class UnlockPanelManager {
       this.closeCallback = params.closeCallback;
     }
 
-    console.log('Init UnlockPanelManager', { params });
     return this.getInstance();
   }
 

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
@@ -65,10 +65,11 @@ export type UnlockPanelManagerInitParamsType = {
    */
   allowedProviders?: AllowedProviderType[] | null;
   /**
-   * Callback function to handle closing the sidebar
-   * when the login process is not initiated.
+   * Callback function to handle UI behavior when the unlock panel is closed
+   * without completing the login process.
    *
-   * This can be useful in scenarios where the user chooses not to proceed with login
+   * Common use case: redirecting the user away from the `/unlock` route
+   * (e.g., back to the homepage or a previous screen) when login is cancelled or skipped.
    */
   closeCallback?: CloseCallbackType;
 };

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
@@ -36,6 +36,7 @@ export type CustomProviderViewType<
 export type LoginCallbackType = () => void;
 
 export type LoginHandlerType = LoginFunctonType | LoginCallbackType;
+export type CloseCallbackType = () => void;
 
 export type UnlockPanelManagerInitParamsType = {
   /**
@@ -63,4 +64,11 @@ export type UnlockPanelManagerInitParamsType = {
    * List of allowed providers
    */
   allowedProviders?: AllowedProviderType[] | null;
+  /**
+   * Callback function to handle closing the sidebar
+   * when the login process is not initiated.
+   *
+   * This can be useful in scenarios where the user chooses not to proceed with login
+   */
+  closeCallback?: CloseCallbackType;
 };


### PR DESCRIPTION
### Feature
Add `closeCallback` support to `UnlockPanelManager` to allow handling redirection or UI cleanup when login is not performed.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
