### PR TITLE
Refactor provider types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Updated ProviderTypesEnum from enum to const](https://github.com/multiversx/mx-sdk-dapp/pull/1450)
+
 ## [[5.0.0-alpha.6](https://github.com/multiversx/mx-sdk-dapp/pull/1449)] - 2025-06-10
 
 - [Added support for dyamic Wallet address](https://github.com/multiversx/mx-sdk-dapp/pull/1447)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@multiversx/sdk-wallet": "4.6.0",
     "@multiversx/sdk-wallet-connect-provider": "6.0.1",
     "@multiversx/sdk-web-wallet-cross-window-provider": "3.1.0",
-    "@multiversx/sdk-web-wallet-iframe-provider": "3.0.0",
+    "@multiversx/sdk-web-wallet-iframe-provider": "3.0.1",
     "@multiversx/sdk-web-wallet-provider": "5.0.0",
     "@multiversx/sdk-webview-provider": "3.0.1",
     "immer": "10.1.1",

--- a/src/constants/providerFactory.constants.ts
+++ b/src/constants/providerFactory.constants.ts
@@ -1,11 +1,15 @@
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 
-export const providerLabels: Record<string, string> = {
+export const providerLabels: Record<ProviderType, string> = {
   [ProviderTypeEnum.crossWindow]: 'MultiversX Web Wallet',
   [ProviderTypeEnum.extension]: 'MultiversX Wallet Extension',
   [ProviderTypeEnum.walletConnect]: 'xPortal App',
   [ProviderTypeEnum.ledger]: 'Ledger',
   [ProviderTypeEnum.metamask]: 'MetaMask Snap',
   [ProviderTypeEnum.passkey]: 'Passkey',
+  [ProviderTypeEnum.webview]: 'Webview',
   [ProviderTypeEnum.none]: ''
 };

--- a/src/managers/UnlockPanelManager/UnlockPanelManager.ts
+++ b/src/managers/UnlockPanelManager/UnlockPanelManager.ts
@@ -6,7 +6,8 @@ import {
   IProviderBase,
   IProviderFactory,
   ICustomProvider,
-  ProviderTypeEnum
+  ProviderTypeEnum,
+  ProviderType
 } from 'providers/types/providerFactory.types';
 import { networkSelector } from 'store/selectors';
 import { getState } from 'store/store';
@@ -149,6 +150,19 @@ export class UnlockPanelManager extends SidePanelBaseManager<
       ...customProviders.map((p) => p.type)
     ];
 
+    const customProviderLabels = customProviders.reduce(
+      (acc, provider) => {
+        acc[provider.type] = provider.name;
+        return acc;
+      },
+      {} as Record<ProviderType, string>
+    );
+
+    const allAvailableLabels = {
+      ...providerLabels,
+      ...customProviderLabels
+    };
+
     const allowedProviderTypes = UnlockPanelManager.allowedProviders
       ? UnlockPanelManager?.allowedProviders
           .map((p) => p.type)
@@ -164,7 +178,7 @@ export class UnlockPanelManager extends SidePanelBaseManager<
       }
 
       return {
-        name: type in providerLabels ? providerLabels[type] : type,
+        name: type in allAvailableLabels ? allAvailableLabels[type] : type,
         type
       };
     });

--- a/src/managers/UnlockPanelManager/UnlockPanelManager.types.ts
+++ b/src/managers/UnlockPanelManager/UnlockPanelManager.types.ts
@@ -1,7 +1,7 @@
 import {
   ICustomProvider,
   IProviderFactory,
-  ProviderTypeEnum
+  ProviderType
 } from 'providers/types/providerFactory.types';
 
 export enum UnlockPanelEventsEnum {
@@ -21,18 +21,17 @@ export type LoginFunctonType = ({
   anchor
 }: IProviderFactory) => Promise<void>;
 
-export type AllowedProviderType = ICustomProvider['type'];
-
-export type CustomProviderViewType<
-  T extends ProviderTypeEnum = ProviderTypeEnum
-> = Omit<ICustomProvider<T>, 'constructor'>;
+export type CustomProviderViewType<T extends ProviderType = ProviderType> =
+  Omit<ICustomProvider<T>, 'constructor'>;
 
 export type LoginCallbackType = () => void;
 
 export type LoginHandlerType = LoginFunctonType | LoginCallbackType;
 export type OnCloseUnlockPanelType = () => void;
 
-export type UnlockPanelManagerInitParamsType = {
+export type UnlockPanelManagerInitParamsType<
+  T extends ProviderType = ProviderType
+> = {
   /**
      * Accepts:
      * - 1️⃣ a `callback` that is executed after login is performed
@@ -58,7 +57,7 @@ export type UnlockPanelManagerInitParamsType = {
   /**
    * List of allowed providers
    */
-  allowedProviders?: AllowedProviderType[] | null;
+  allowedProviders?: ICustomProvider<T>[] | null;
   /**
    * Callback function to handle UI behavior when the unlock panel is closed
    * without completing the login process.

--- a/src/providers/ProviderFactory.ts
+++ b/src/providers/ProviderFactory.ts
@@ -122,18 +122,19 @@ export class ProviderFactory {
     const dappProvider = new DappProvider(createdProvider);
 
     setAccountProvider(dappProvider);
-    const providerType = type as ProviderTypeEnum;
-    setProviderType(providerType);
+    setProviderType(type);
 
-    const shouldClearInitiatedLogins = [
-      ProviderTypeEnum.crossWindow,
-      ProviderTypeEnum.metamask,
-      ProviderTypeEnum.passkey
-    ].includes(providerType);
+    const shouldClearInitiatedLogins =
+      type in
+      [
+        ProviderTypeEnum.crossWindow,
+        ProviderTypeEnum.metamask,
+        ProviderTypeEnum.passkey
+      ];
 
     // Clear initiated logins and skip the login method if it's crossWindow or metamask
     clearInitiatedLogins(
-      shouldClearInitiatedLogins ? { skipLoginMethod: providerType } : null
+      shouldClearInitiatedLogins ? { skipLoginMethod: type } : null
     );
 
     return dappProvider;

--- a/src/providers/helpers/clearInitiatedLogins.ts
+++ b/src/providers/helpers/clearInitiatedLogins.ts
@@ -1,10 +1,10 @@
 import { CrossWindowProvider } from 'lib/sdkWebWalletCrossWindowProvider';
 import { IframeProvider } from 'lib/sdkWebWalletIframeProvider';
-import { ProviderTypeEnum } from '../types/providerFactory.types';
+import { ProviderTypeEnum, ProviderType } from '../types/providerFactory.types';
 
 export const clearInitiatedLogins = (
   props?: {
-    skipLoginMethod: ProviderTypeEnum;
+    skipLoginMethod: ProviderType;
   } | null
 ) => {
   Object.values(ProviderTypeEnum).forEach((method) => {

--- a/src/providers/helpers/emptyProvider.ts
+++ b/src/providers/helpers/emptyProvider.ts
@@ -5,6 +5,7 @@ import {
 } from '@multiversx/sdk-dapp-utils/out';
 import {
   IProvider,
+  ProviderType,
   ProviderTypeEnum
 } from 'providers/types/providerFactory.types';
 
@@ -113,7 +114,7 @@ export class EmptyProvider implements IProvider {
     throw new Error(notInitializedError('getAddress'));
   }
 
-  getType(): ProviderTypeEnum {
+  getType(): ProviderType {
     return ProviderTypeEnum.none;
   }
 }

--- a/src/providers/strategies/BaseProviderStrategy/BaseProviderStrategy.ts
+++ b/src/providers/strategies/BaseProviderStrategy/BaseProviderStrategy.ts
@@ -5,10 +5,7 @@ import { Transaction, Message } from 'lib/sdkCore';
 import { IDAppProviderOptions } from 'lib/sdkDappUtils';
 import { PendingTransactionsEventsEnum } from 'managers/internal/PendingTransactionsStateManager';
 import { getAddress } from 'methods/account/getAddress';
-import {
-  IProvider,
-  ProviderTypeEnum
-} from 'providers/types/providerFactory.types';
+import { IProvider, ProviderType } from 'providers/types/providerFactory.types';
 import { ProviderErrorsEnum } from 'types/provider.types';
 import { getPendingTransactionsHandlers } from '../helpers';
 
@@ -16,7 +13,10 @@ export type LoginOptionsTypes = {
   token?: string;
 };
 
-export abstract class BaseProviderStrategy implements IProvider {
+export abstract class BaseProviderStrategy<
+  T extends ProviderType = ProviderType
+> implements IProvider<T>
+{
   protected address?: string = '';
   protected _login:
     | ((options?: LoginOptionsTypes) => Promise<IProviderAccount | null>)
@@ -32,7 +32,7 @@ export abstract class BaseProviderStrategy implements IProvider {
 
   abstract init(): Promise<boolean>;
   abstract logout(): Promise<boolean>;
-  abstract getType(): ProviderTypeEnum;
+  abstract getType(): T;
 
   abstract getAddress(): Promise<string | undefined>;
   abstract setAccount(account: IDAppProviderAccount): void;

--- a/src/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy.ts
+++ b/src/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy.ts
@@ -3,7 +3,10 @@ import { isBrowserWithPopupConfirmation } from 'constants/browser.constants';
 import { providerLabels } from 'constants/providerFactory.constants';
 import { Message, Transaction } from 'lib/sdkCore';
 import { CrossWindowProvider } from 'lib/sdkWebWalletCrossWindowProvider';
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 import { crossWindowConfigSelector } from 'store/selectors';
 import { networkSelector } from 'store/selectors/networkSelectors';
 import { getState } from 'store/store';
@@ -53,7 +56,7 @@ export class CrossWindowProviderStrategy extends BaseProviderStrategy {
     return this.provider.logout();
   }
 
-  getType(): ProviderTypeEnum {
+  getType(): ProviderType {
     return ProviderTypeEnum.crossWindow;
   }
 

--- a/src/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
+++ b/src/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
@@ -3,7 +3,10 @@ import { ExtensionProvider } from '@multiversx/sdk-extension-provider/out/extens
 import { providerLabels } from 'constants/providerFactory.constants';
 import { Message, Transaction } from 'lib/sdkCore';
 
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 import { ProviderErrorsEnum } from 'types/provider.types';
 import { BaseProviderStrategy } from '../BaseProviderStrategy/BaseProviderStrategy';
 import { signMessage } from '../helpers/signMessage/signMessage';
@@ -48,7 +51,7 @@ export class ExtensionProviderStrategy extends BaseProviderStrategy {
     return this.provider.logout();
   }
 
-  getType(): ProviderTypeEnum {
+  getType(): ProviderType {
     return ProviderTypeEnum.extension;
   }
 

--- a/src/providers/strategies/IframeProviderStrategy/IframeProviderStrategy.ts
+++ b/src/providers/strategies/IframeProviderStrategy/IframeProviderStrategy.ts
@@ -4,7 +4,10 @@ import { IframeLoginTypes } from '@multiversx/sdk-web-wallet-iframe-provider/out
 import { providerLabels } from 'constants/providerFactory.constants';
 import { Message, Transaction } from 'lib/sdkCore';
 import { IframeProvider } from 'lib/sdkWebWalletIframeProvider';
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 import { networkSelector } from 'store/selectors/networkSelectors';
 import { getState } from 'store/store';
 import { ProviderErrorsEnum } from 'types/provider.types';
@@ -12,7 +15,14 @@ import { IframeProviderType } from './types';
 import { BaseProviderStrategy } from '../BaseProviderStrategy/BaseProviderStrategy';
 import { signMessage } from '../helpers/signMessage/signMessage';
 
-const IFRAME_PROVIDER_MAP: Record<IframeLoginTypes, ProviderTypeEnum> = {
+type IframeProviderStrategyType =
+  | typeof ProviderTypeEnum.passkey
+  | typeof ProviderTypeEnum.metamask;
+
+const IFRAME_PROVIDER_MAP: Record<
+  IframeLoginTypes,
+  IframeProviderStrategyType
+> = {
   passkey: ProviderTypeEnum.passkey,
   metamask: ProviderTypeEnum.metamask
 };
@@ -67,7 +77,7 @@ export class IframeProviderStrategy extends BaseProviderStrategy {
     return this.provider.logout();
   }
 
-  getType(): ProviderTypeEnum {
+  getType(): ProviderType {
     return IFRAME_PROVIDER_MAP[this.type];
   }
 

--- a/src/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
+++ b/src/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
@@ -8,7 +8,10 @@ import { defineCustomElements } from 'lib/sdkDappUi';
 import { LedgerConnectStateManager } from 'managers/internal/LedgerConnectStateManager/LedgerConnectStateManager';
 import { ToastIconsEnum } from 'managers/internal/ToastManager/helpers/getToastDataStateByStatus';
 import { getIsLoggedIn } from 'methods/account/getIsLoggedIn';
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 import { createCustomToast } from 'store/actions/toasts/toastsActions';
 import { ProviderErrorsEnum } from 'types/provider.types';
 import { getLedgerProvider } from './helpers';
@@ -65,7 +68,7 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
     return this.provider.logout();
   }
 
-  getType(): ProviderTypeEnum {
+  getType(): ProviderType {
     return ProviderTypeEnum.ledger;
   }
 

--- a/src/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
+++ b/src/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
@@ -10,7 +10,10 @@ import { Message, Transaction } from 'lib/sdkCore';
 import { defineCustomElements } from 'lib/sdkDappUi';
 import { WalletConnectStateManager } from 'managers/internal/WalletConnectStateManager/WalletConnectStateManager';
 import { getIsLoggedIn } from 'methods/account/getIsLoggedIn';
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 import { logoutAction } from 'store/actions';
 import { chainIdSelector, nativeAuthConfigSelector } from 'store/selectors';
 import { getState } from 'store/store';
@@ -61,7 +64,7 @@ export class WalletConnectProviderStrategy extends BaseProviderStrategy {
     return this.provider.logout();
   }
 
-  getType(): ProviderTypeEnum {
+  getType(): ProviderType {
     return ProviderTypeEnum.walletConnect;
   }
 

--- a/src/providers/strategies/WebviewProviderStrategy/WebviewProviderStrategy.ts
+++ b/src/providers/strategies/WebviewProviderStrategy/WebviewProviderStrategy.ts
@@ -1,7 +1,10 @@
 import { IDAppProviderAccount } from '@multiversx/sdk-dapp-utils/out';
 import { WebviewProvider } from '@multiversx/sdk-webview-provider/out/WebviewProvider';
 import { Message, Transaction } from 'lib/sdkCore';
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 import { ProviderErrorsEnum } from 'types/provider.types';
 import { BaseProviderStrategy } from '../BaseProviderStrategy/BaseProviderStrategy';
 
@@ -27,7 +30,7 @@ export class WebviewProviderStrategy extends BaseProviderStrategy {
     return this.provider.logout();
   }
 
-  getType(): ProviderTypeEnum {
+  getType(): ProviderType {
     return ProviderTypeEnum.webview;
   }
 

--- a/src/providers/strategies/helpers/signMessage/signMessage.ts
+++ b/src/providers/strategies/helpers/signMessage/signMessage.ts
@@ -7,10 +7,7 @@ import {
 } from 'providers/types/providerFactory.types';
 import { SigningWarningsEnum } from 'types/enums.types';
 import { getPendingTransactionsHandlers } from '../getPendingTransactionsHandlers';
-
-function isProviderType(type: string): type is ProviderType {
-  return Object.values(ProviderTypeEnum).includes(type as ProviderType);
-}
+import { ProviderFactory } from 'providers/ProviderFactory';
 
 type SignMessageWithModalPropsType<T> = {
   message: Message;
@@ -31,6 +28,24 @@ export async function signMessage<T>({
         cancelAction
       });
 
+      const allProviders = Object.values(ProviderFactory.customProviders);
+      const allCustomProviderLabels = allProviders.reduce(
+        (acc, provider) => {
+          acc[provider.type] = provider.name;
+          return acc;
+        },
+        {} as Record<ProviderType, string>
+      );
+
+      const allProviderLabels = {
+        ...providerLabels,
+        ...allCustomProviderLabels
+      };
+
+      function isProviderType(type: string): type is ProviderType {
+        return allProviders.some((provider) => provider.type === type);
+      }
+
       const handleClose = async () => {
         await onClose({ shouldCancelAction: true });
         reject({ message: SigningWarningsEnum.cancelled });
@@ -46,7 +61,7 @@ export async function signMessage<T>({
         : ProviderTypeEnum.none;
 
       manager.updateData({
-        name: providerLabels[providerKey],
+        name: allProviderLabels[providerKey],
         type: providerKey
       });
 

--- a/src/providers/strategies/helpers/signMessage/signMessage.ts
+++ b/src/providers/strategies/helpers/signMessage/signMessage.ts
@@ -3,7 +3,8 @@ import { Message } from 'lib/sdkCore';
 import { PendingTransactionsEventsEnum } from 'managers/internal/PendingTransactionsStateManager/types/pendingTransactions.types';
 import {
   ProviderType,
-  ProviderTypeEnum
+  ProviderTypeEnum,
+  ICustomProvider
 } from 'providers/types/providerFactory.types';
 import { SigningWarningsEnum } from 'types/enums.types';
 import { getPendingTransactionsHandlers } from '../getPendingTransactionsHandlers';
@@ -15,6 +16,12 @@ type SignMessageWithModalPropsType<T> = {
   cancelAction?: () => Promise<T> | undefined;
   providerType: string;
 };
+
+const isProviderType = (
+  allProviders: ICustomProvider[],
+  type: string
+): type is ProviderType =>
+  allProviders.some((provider) => provider.type === type);
 
 export async function signMessage<T>({
   message,
@@ -42,10 +49,6 @@ export async function signMessage<T>({
         ...allCustomProviderLabels
       };
 
-      function isProviderType(type: string): type is ProviderType {
-        return allProviders.some((provider) => provider.type === type);
-      }
-
       const handleClose = async () => {
         await onClose({ shouldCancelAction: true });
         reject({ message: SigningWarningsEnum.cancelled });
@@ -56,7 +59,7 @@ export async function signMessage<T>({
         handleClose
       );
 
-      const providerKey = isProviderType(providerType)
+      const providerKey = isProviderType(allProviders, providerType)
         ? providerType
         : ProviderTypeEnum.none;
 

--- a/src/providers/strategies/helpers/signMessage/signMessage.ts
+++ b/src/providers/strategies/helpers/signMessage/signMessage.ts
@@ -1,8 +1,16 @@
 import { providerLabels } from 'constants/providerFactory.constants';
 import { Message } from 'lib/sdkCore';
 import { PendingTransactionsEventsEnum } from 'managers/internal/PendingTransactionsStateManager/types/pendingTransactions.types';
+import {
+  ProviderType,
+  ProviderTypeEnum
+} from 'providers/types/providerFactory.types';
 import { SigningWarningsEnum } from 'types/enums.types';
 import { getPendingTransactionsHandlers } from '../getPendingTransactionsHandlers';
+
+function isProviderType(type: string): type is ProviderType {
+  return Object.values(ProviderTypeEnum).includes(type as ProviderType);
+}
 
 type SignMessageWithModalPropsType<T> = {
   message: Message;
@@ -33,9 +41,13 @@ export async function signMessage<T>({
         handleClose
       );
 
+      const providerKey = isProviderType(providerType)
+        ? providerType
+        : ProviderTypeEnum.none;
+
       manager.updateData({
-        name: providerLabels[providerType],
-        type: providerType
+        name: providerLabels[providerKey],
+        type: providerKey
       });
 
       try {

--- a/src/providers/types/providerFactory.types.ts
+++ b/src/providers/types/providerFactory.types.ts
@@ -1,6 +1,6 @@
 import type { IDAppProviderBase } from '@multiversx/sdk-dapp-utils';
 
-export interface IProvider<T extends ProviderTypeEnum = ProviderTypeEnum>
+export interface IProvider<T extends ProviderType = ProviderType>
   extends IDAppProviderBase {
   init: () => Promise<boolean>;
   login: (options?: { callbackUrl?: string; token?: string }) => Promise<{
@@ -13,7 +13,7 @@ export interface IProvider<T extends ProviderTypeEnum = ProviderTypeEnum>
   logout: () => Promise<boolean>;
   cancelLogin?: () => void;
   setShouldShowConsentPopup?: (shouldShow: boolean) => void;
-  getType: () => T[keyof T] | string;
+  getType: () => T;
   getAddress(): Promise<string | undefined>;
 }
 
@@ -23,30 +23,31 @@ export interface IProviderConfig {
   };
 }
 
-export enum ProviderTypeEnum {
-  extension = 'extension',
-  metamask = 'metamask',
-  passkey = 'passkey',
-  walletConnect = 'walletConnect',
-  ledger = 'ledger',
-  crossWindow = 'crossWindow',
-  webview = 'webview',
-  none = ''
-}
+export const ProviderTypeEnum = {
+  extension: 'extension',
+  metamask: 'metamask',
+  passkey: 'passkey',
+  walletConnect: 'walletConnect',
+  ledger: 'ledger',
+  crossWindow: 'crossWindow',
+  webview: 'webview',
+  none: ''
+} as const;
 
-export interface IProviderFactory<
-  T extends ProviderTypeEnum = ProviderTypeEnum
-> {
-  type: T[keyof T];
+export type ProviderType =
+  (typeof ProviderTypeEnum)[keyof typeof ProviderTypeEnum];
+
+export interface IProviderFactory<T extends ProviderType = ProviderType> {
+  type: T;
   anchor?: HTMLElement;
 }
 
-export interface IProviderBase<T extends ProviderTypeEnum = ProviderTypeEnum> {
+export interface IProviderBase<T extends ProviderType = ProviderType> {
   name: string;
-  type: T[keyof T];
+  type: T;
   iconUrl?: string;
 }
-export interface ICustomProvider<T extends ProviderTypeEnum = ProviderTypeEnum>
+export interface ICustomProvider<T extends ProviderType = ProviderType>
   extends IProviderBase<T> {
   constructor: (options?: {
     address?: string;

--- a/src/store/actions/loginInfo/loginInfoActions.ts
+++ b/src/store/actions/loginInfo/loginInfoActions.ts
@@ -1,4 +1,7 @@
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 import {
   LedgerLoginType,
   LoginInfoType,
@@ -7,7 +10,7 @@ import {
 import { getStore } from 'store/store';
 import { TokenLoginType } from 'types/login.types';
 
-export const setProviderType = <T extends ProviderTypeEnum = ProviderTypeEnum>(
+export const setProviderType = <T extends ProviderType = ProviderType>(
   providerType: T
 ) =>
   getStore().setState(

--- a/src/store/actions/sharedActions/sharedActions.ts
+++ b/src/store/actions/sharedActions/sharedActions.ts
@@ -1,14 +1,15 @@
 import { Address } from 'lib/sdkCore';
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import {
+  ProviderTypeEnum,
+  ProviderType
+} from 'providers/types/providerFactory.types';
 import { resetStore } from 'store/middleware/logoutMiddleware';
 import { getStore } from 'store/store';
 
 export const logoutAction = () => getStore().setState(resetStore);
-export interface LoginActionPayloadType<
-  T extends ProviderTypeEnum = ProviderTypeEnum
-> {
+export interface LoginActionPayloadType<T extends ProviderType = ProviderType> {
   address: string;
-  providerType: T[keyof T];
+  providerType: T;
 }
 
 export const loginAction = ({

--- a/src/store/slices/loginInfo/loginInfo.types.ts
+++ b/src/store/slices/loginInfo/loginInfo.types.ts
@@ -1,4 +1,4 @@
-import { ProviderTypeEnum } from 'providers/types/providerFactory.types';
+import { ProviderType } from 'providers/types/providerFactory.types';
 import { TokenLoginType } from 'types/login.types';
 
 export interface WalletConnectLoginType {
@@ -17,10 +17,8 @@ export interface LoginInfoType {
   expires: number;
 }
 
-export interface LoginInfoSliceType<
-  T extends ProviderTypeEnum = ProviderTypeEnum
-> {
-  providerType: T[keyof T] | null;
+export interface LoginInfoSliceType<T extends ProviderType = ProviderType> {
+  providerType: T | null;
   walletConnectLogin: WalletConnectLoginType | null;
   ledgerLogin: LedgerLoginType | null;
   tokenLogin: TokenLoginType | null;


### PR DESCRIPTION
### Feature
Update provider type system to use a more type-safe approach by converting `ProviderTypeEnum` from an enum to a const object and introducing a `ProviderType` type. This improves type safety and maintainability across the codebase.


### Root cause
The enum approach made it harder to ensure type consistency across the codebase and made it more difficult to extend with new provider types.

### Fix
1. Convert `ProviderTypeEnum` from an enum to a const object
2. Introduce a new `ProviderType` type derived from the const object
3. Update all provider-related interfaces and classes to use the new type system
4. Update provider strategy implementations to use the new type system
5. Update store actions and types to work with the new type system
6. Update provider factory and related utilities to use the new type system

### Additional changes
- Updated package dependencies:
  - `@multiversx/sdk-web-wallet-iframe-provider` from 3.0.0 to 3.0.1
- Improved type safety in provider labels and provider factory constants
- Enhanced type checking in provider strategy implementations
- Updated sign message functionality to handle provider types 

### Contains breaking changes
- [x] No
- [ ] Yes

### Updated CHANGELOG
- [ ] No
- [x] Yes

### Testing
- [x] User testing
- [ ] Unit tests