### PR TITLE
Fix webview logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v4.2.1](https://github.com/multiversx/mx-sdk-dapp/pull/1455)] - 2025-06-16
+
+- [Fixed webview logout](https://github.com/multiversx/mx-sdk-dapp/pull/1456)
+
 ## [[v4.2.0](https://github.com/multiversx/mx-sdk-dapp/pull/1455)] - 2025-06-13
 
 - [Added send login token on webview login](https://github.com/multiversx/mx-sdk-dapp/pull/1455)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -3,15 +3,11 @@ import { IDAppProviderAccount } from '@multiversx/sdk-dapp-utils/out';
 import { providerNotInitializedError } from '@multiversx/sdk-dapp-utils/out/helpers/providerNotInitializedError';
 import { WebviewProvider } from '@multiversx/sdk-webview-provider/out/WebviewProvider';
 import { logoutAction } from 'reduxStore/commonActions';
-import { store } from 'reduxStore/store';
+import { persistor, store } from 'reduxStore/store';
 import { loginWithNativeAuthToken } from 'services/nativeAuth/helpers/loginWithNativeAuthToken';
 import { removeAllTransactionsToSign } from 'services/transactions';
 import { IDappProvider } from 'types/dappProvider.types';
-import {
-  setAccountProvider,
-  setExternalProviderAsAccountProvider
-} from '../accountProvider';
-import { emptyProvider } from 'utils';
+import { setExternalProviderAsAccountProvider } from '../accountProvider';
 
 /**
  * This is an experimental provider that uses @multiversx/webview-provider to handle the communication between .
@@ -59,8 +55,7 @@ export class ExperimentalWebviewProvider implements IDappProvider {
   };
 
   logout = async () => {
-    setAccountProvider(emptyProvider);
-    store.dispatch(logoutAction());
+    persistor.purge(); // clear the storage
     return await this._provider.logout();
   };
 

--- a/src/providers/experimentalWebViewProvider/useInitiateExperimentalWebviewLogin.ts
+++ b/src/providers/experimentalWebViewProvider/useInitiateExperimentalWebviewLogin.ts
@@ -1,7 +1,10 @@
 import { SECOND_LOGIN_ATTEMPT_ERROR } from 'constants/errorsMessages';
+import { version } from 'constants/index';
 import { clearInitiatedLogins } from 'hooks/login/helpers';
+import { useLoginService } from 'hooks/login/useLoginService';
 import { setExternalProvider } from 'providers/accountProvider';
 import { loginAction } from 'reduxStore/commonActions';
+import { useDispatch } from 'reduxStore/DappProviderContext';
 import {
   emptyAccount,
   setAccount,
@@ -10,12 +13,9 @@ import {
 } from 'reduxStore/slices';
 
 import { LoginMethodsEnum } from 'types/enums.types';
+import { getAccessTokenFromSearchParams } from 'utils/account/getAccessTokenFromSearchParams';
 import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { ExperimentalWebviewProvider } from './ExperimentalWebviewProvider';
-import { getAccessTokenFromSearchParams } from 'utils/account/getAccessTokenFromSearchParams';
-import { version } from 'constants/index';
-import { useDispatch } from 'reduxStore/DappProviderContext';
-import { useLoginService } from 'hooks/login/useLoginService';
 
 export function useInitiateExperimentalWebviewLogin() {
   const isLoggedIn = getIsLoggedIn();

--- a/src/reduxStore/middlewares/loginSessionMiddleware.ts
+++ b/src/reduxStore/middlewares/loginSessionMiddleware.ts
@@ -14,7 +14,7 @@ const throttledSetNewExpires = throttle(() => {
   setLoginExpiresAt(getNewLoginExpiresTimestamp());
 }, 5000);
 
-export const loginSessionMiddleware: any =
+export const loginSessionMiddleware =
   (store: any) =>
   (next: (action: PayloadAction) => void) =>
   (action: PayloadAction) => {
@@ -34,7 +34,8 @@ export const loginSessionMiddleware: any =
     }
 
     if (loginTimestamp == null) {
-      return setLoginExpiresAt(getNewLoginExpiresTimestamp());
+      setLoginExpiresAt(getNewLoginExpiresTimestamp());
+      return next(action);
     }
 
     // create a unique key for this account and it's allowed session

--- a/src/utils/logout.ts
+++ b/src/utils/logout.ts
@@ -59,6 +59,7 @@ export async function logout(
   const provider = getAccountProvider();
   const providerType = getProviderType(provider);
   const isWalletProvider = providerType === LoginMethodsEnum.wallet;
+  const isExtraProvider = providerType === LoginMethodsEnum.extra;
   const isProviderInitialised = provider?.isInitialized?.() === true;
 
   if (shouldAttemptReLogin && provider?.relogin != null) {
@@ -119,7 +120,9 @@ export async function logout(
   } catch (err) {
     console.error('Logging out error:', err);
   } finally {
-    if (!isWalletProvider) {
+    const skipReload = isWalletProvider || isExtraProvider;
+
+    if (!skipReload) {
       redirectToCallbackUrl({
         callbackUrl: url,
         onRedirect

--- a/src/wrappers/DappProvider/DappProvider.tsx
+++ b/src/wrappers/DappProvider/DappProvider.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 import { ProviderInitializer } from 'components/ProviderInitializer/ProviderInitializer';
 import { setExternalProvider } from 'providers/accountProvider';
+import { useInitiateExperimentalWebviewLogin } from 'providers/experimentalWebViewProvider/useInitiateExperimentalWebviewLogin';
 import { DappCoreContext } from 'reduxStore/DappProviderContext';
 import { persistor, store } from 'reduxStore/store';
 import { CustomNetworkType, IDappProvider, DappConfigType } from '../../types';
@@ -11,7 +12,6 @@ import {
   UseAppInitializerPropsType
 } from './../../wrappers/AppInitializer';
 import { CustomComponents, CustomComponentsType } from './CustomComponents';
-import { useInitiateExperimentalWebviewLogin } from 'providers/experimentalWebViewProvider/useInitiateExperimentalWebviewLogin';
 
 export { DappConfigType };
 


### PR DESCRIPTION
### Issue
Hub webview logout not working

### Reproduce
Login to hub and press logout from dApp => no logout action is performed

### Root cause

1. The finally clause was causing a redirect before webview provider was able to send the logout request
2. Clearing the storage was not working on logout from webview

### Fix

1. Added condition to skip page reload on logout with extra provider
2. Clear the storage in provider logout by calling `persistor.purge()`

### Additional changes
lint

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
