### PR TITLE
Added `relayer` and `relayerSignature` in the transaction in `transformAndSignTransactions`

### DIFF
--- a/.github/workflows/pre-merge-unit-tests.yml
+++ b/.github/workflows/pre-merge-unit-tests.yml
@@ -1,7 +1,7 @@
-name: "Jest Unit Tests"
+name: 'Jest Unit Tests'
 on:
   pull_request:
-    branches: [main]
+    branches: [main, old-main]
     paths:
       - 'src/**'
       - '**.js'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Added `relayer` and `relayerSignature` in the transaction in `transformAndSignTransactions`](https://github.com/multiversx/mx-sdk-dapp/pull/1456)
+
 ## [[v4.2.1](https://github.com/multiversx/mx-sdk-dapp/pull/1455)] - 2025-06-16
 
 - [Fixed webview logout](https://github.com/multiversx/mx-sdk-dapp/pull/1456)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v4.2.2](https://github.com/multiversx/mx-sdk-dapp/pull/1456)] - 2025-06-17
+
 - [Added `relayer` and `relayerSignature` in the transaction in `transformAndSignTransactions`](https://github.com/multiversx/mx-sdk-dapp/pull/1457)
 
 ## [[v4.2.1](https://github.com/multiversx/mx-sdk-dapp/pull/1455)] - 2025-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Added `relayer` and `relayerSignature` in the transaction in `transformAndSignTransactions`](https://github.com/multiversx/mx-sdk-dapp/pull/1456)
+- [Added `relayer` and `relayerSignature` in the transaction in `transformAndSignTransactions`](https://github.com/multiversx/mx-sdk-dapp/pull/1457)
 
 ## [[v4.2.1](https://github.com/multiversx/mx-sdk-dapp/pull/1455)] - 2025-06-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",

--- a/src/services/transactions/__tests__/transformAndSignTransactions.test.ts
+++ b/src/services/transactions/__tests__/transformAndSignTransactions.test.ts
@@ -1,0 +1,114 @@
+import { Address, Transaction } from '@multiversx/sdk-core';
+import { transformAndSignTransactions } from '../transformAndSignTransactions';
+import * as accountUtils from 'utils/account/getAccount';
+import * as nonceUtils from 'utils/account/getLatestNonce';
+import { newTransaction } from 'models/newTransaction';
+
+jest.mock('@multiversx/sdk-core', () => {
+  const originalModule = jest.requireActual('@multiversx/sdk-core');
+
+  return {
+    ...originalModule,
+    Address: jest.fn().mockImplementation((address) => ({
+      toHex: jest.fn().mockReturnValue(address),
+      hex: jest.fn().mockReturnValue(address)
+    }))
+  };
+});
+
+jest.mock('reduxStore/store', () => ({
+  store: {
+    getState: jest.fn(() => ({}))
+  }
+}));
+
+jest.mock('reduxStore/selectors', () => ({
+  addressSelector: jest.fn(() => 'erd1sender'),
+  chainIDSelector: jest.fn(() => ({ valueOf: () => 'T' }))
+}));
+
+jest.mock('utils/account/getAccount', () => ({
+  getAccount: jest.fn()
+}));
+
+jest.mock('utils/account/getLatestNonce', () => ({
+  getLatestNonce: jest.fn()
+}));
+
+jest.mock('models/newTransaction', () => ({
+  newTransaction: jest.fn()
+}));
+
+describe('transformAndSignTransactions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (accountUtils.getAccount as jest.Mock).mockResolvedValue({ nonce: 5 });
+    (nonceUtils.getLatestNonce as jest.Mock).mockReturnValue(5);
+  });
+
+  it('should transform simple transactions to Transaction objects', async () => {
+    const simpleTransaction = {
+      value: '100',
+      receiver: 'erd1receiver',
+      data: 'test-data',
+      gasPrice: 1000000000,
+      gasLimit: 50000,
+      chainID: 'T'
+    };
+
+    const mockTransaction = {
+      id: 'mock-transaction'
+    } as unknown as Transaction;
+    (newTransaction as jest.Mock).mockReturnValue(mockTransaction);
+
+    const result = await transformAndSignTransactions({
+      transactions: [simpleTransaction]
+    });
+
+    expect(result).toEqual([mockTransaction]);
+    expect(newTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: simpleTransaction.value,
+        receiver: simpleTransaction.receiver,
+        data: simpleTransaction.data,
+        gasPrice: simpleTransaction.gasPrice,
+        gasLimit: simpleTransaction.gasLimit,
+        chainID: simpleTransaction.chainID,
+        nonce: 5
+      })
+    );
+  });
+
+  it('should include relayer information when present', async () => {
+    const transactionWithRelayer = {
+      value: '100',
+      receiver: 'erd1receiver',
+      data: 'test-data',
+      gasPrice: 1000000000,
+      gasLimit: 50000,
+      chainID: 'T',
+      relayer: 'erd1relayer',
+      relayerSignature: 'signature123'
+    };
+
+    const mockTransaction = {
+      id: 'mock-transaction-with-relayer'
+    } as unknown as Transaction;
+    (newTransaction as jest.Mock).mockReturnValue(mockTransaction);
+
+    const result = await transformAndSignTransactions({
+      transactions: [transactionWithRelayer]
+    });
+
+    expect(result).toEqual([mockTransaction]);
+    expect(newTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: transactionWithRelayer.value,
+        receiver: transactionWithRelayer.receiver,
+        data: transactionWithRelayer.data,
+        relayer: transactionWithRelayer.relayer,
+        relayerSignature: transactionWithRelayer.relayerSignature
+      })
+    );
+  });
+});

--- a/src/services/transactions/__tests__/transformAndSignTransactions.test.ts
+++ b/src/services/transactions/__tests__/transformAndSignTransactions.test.ts
@@ -1,4 +1,4 @@
-import { Address, Transaction } from '@multiversx/sdk-core';
+import { Transaction } from '@multiversx/sdk-core';
 import { transformAndSignTransactions } from '../transformAndSignTransactions';
 import * as accountUtils from 'utils/account/getAccount';
 import * as nonceUtils from 'utils/account/getLatestNonce';

--- a/src/services/transactions/signTransactions.ts
+++ b/src/services/transactions/signTransactions.ts
@@ -28,7 +28,7 @@ export async function signTransactions({
     : [transactions];
 
   const hasValidChainId = transactionsPayload?.every(
-    (tx) => tx.getChainID().valueOf() === storeChainId.valueOf()
+    (tx) => tx.chainID === storeChainId
   );
   if (!hasValidChainId) {
     const notificationPayload = {
@@ -59,8 +59,8 @@ export async function signTransactions({
 
       return {
         ...transaction,
-        senderUsername: tx.getSenderUsername().valueOf(),
-        receiverUsername: tx.getReceiverUsername().valueOf()
+        senderUsername: tx.senderUsername,
+        receiverUsername: tx.receiverUsername
       };
     })
   };

--- a/src/services/transactions/transformAndSignTransactions.ts
+++ b/src/services/transactions/transformAndSignTransactions.ts
@@ -62,13 +62,15 @@ export async function transformAndSignTransactions({
       }),
       guardian,
       guardianSignature,
+      relayer,
+      relayerSignature,
       nonce: transactionNonce = 0
     } = tx;
     let validatedReceiver = receiver;
 
     try {
       const addr = new Address(receiver);
-      validatedReceiver = addr.hex();
+      validatedReceiver = addr.toHex();
     } catch (err) {
       throw ErrorCodesEnum.invalidReceiver;
     }
@@ -87,12 +89,14 @@ export async function transformAndSignTransactions({
       gasPrice,
       gasLimit: Number(gasLimit),
       nonce: Number(computedNonce.valueOf().toString()),
-      sender: new Address(address).hex(),
+      sender: new Address(address).toHex(),
       chainID: transactionsChainId,
       version,
       options,
       guardian,
-      guardianSignature
+      guardianSignature,
+      relayer,
+      relayerSignature
     });
   });
 }

--- a/src/types/transactions.types.ts
+++ b/src/types/transactions.types.ts
@@ -112,6 +112,8 @@ export interface SimpleTransactionType {
   options?: number;
   guardian?: string;
   guardianSignature?: string;
+  relayer?: string;
+  relayerSignature?: string;
   nonce?: number;
 }
 


### PR DESCRIPTION
### Issue
Added support for relayer and relayerSignature in transactions to enable relayed transaction functionality.

### Fix
Added support for relayer and relayerSignature in the transaction transformation process:
- Added relayer and relayerSignature fields in the transaction types
- Updated `transformAndSignTransactions` to handle relayer information
- Added relayer support in the `newTransaction` function
- Added test coverage for relayer functionality

### Contains breaking changes
- [x] No
- [ ] Yes

### Updated CHANGELOG
- [x] No
- [ ] Yes

### Testing
- [x] User testing
- [x] Unit tests