### PR TITLE
Add utility for scam/suspicious content detection in asset messages, with supporting types and dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[5.0.0-alpha.8](https://github.com/multiversx/mx-sdk-dapp/pull/1455)] - 2025-06-19
+
 - [Added `getScamFlag` utility](https://github.com/multiversx/mx-sdk-dapp/pull/1454)
 
 ## [[5.0.0-alpha.7](https://github.com/multiversx/mx-sdk-dapp/pull/1453)] - 2025-06-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[5.0.0-alpha.8](https://github.com/multiversx/mx-sdk-dapp/pull/1455)] - 2025-06-19
+## [[5.0.0-alpha.8](https://github.com/multiversx/mx-sdk-dapp/pull/1459)] - 2025-06-19
 
-- [Added `getScamFlag` utility](https://github.com/multiversx/mx-sdk-dapp/pull/1454)
+- [Added `getScamFlag` utility](https://github.com/multiversx/mx-sdk-dapp/pull/1458)
 
 ## [[5.0.0-alpha.7](https://github.com/multiversx/mx-sdk-dapp/pull/1453)] - 2025-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Added `getScamFlag` utility](https://github.com/multiversx/mx-sdk-dapp/pull/1454)
+
 ## [[5.0.0-alpha.7](https://github.com/multiversx/mx-sdk-dapp/pull/1453)] - 2025-06-13
 
 - [Refactor `refreshNativeAuthTokenLogin` to return netivateAuthToken](https://github.com/multiversx/mx-sdk-dapp/pull/1452)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@multiversx/sdk-web-wallet-provider": "5.0.0",
     "@multiversx/sdk-webview-provider": "3.0.1",
     "immer": "10.1.1",
+    "linkifyjs": "4.3.1",
     "lodash.isempty": "4.4.0",
     "lodash.isequal": "4.5.0",
     "lodash.isstring": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "5.0.0-alpha.7",
+  "version": "5.0.0-alpha.8",
   "main": "out/index.js",
   "module": "out/index.mjs",
   "types": "out/index.d.ts",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './network.types';
 export * from './provider.types';
 export * from './subscriptions.type';
 export * from './websocket.types';
+export * from './suspiciousLink.types';

--- a/src/types/suspiciousLink.types.ts
+++ b/src/types/suspiciousLink.types.ts
@@ -1,0 +1,20 @@
+import { ScamInfoType } from './account.types';
+
+export interface SuspiciousLinkType {
+  isSuspicious: boolean;
+  message: string;
+  textWithLinks: string;
+}
+
+export interface SuspiciousLinkPropsType {
+  message: string;
+  messagePrefix?: string;
+  scamInfo?: ScamInfoType;
+  isNsfw?: boolean;
+  verified?: boolean;
+}
+
+export interface TextWithLinksType {
+  textWithLinks: string;
+  hasLinks: boolean;
+}

--- a/src/utils/transactions/getScamFlag.ts
+++ b/src/utils/transactions/getScamFlag.ts
@@ -1,0 +1,71 @@
+import * as linkify from 'linkifyjs';
+import {
+  SuspiciousLinkType,
+  SuspiciousLinkPropsType,
+  TextWithLinksType
+} from 'types';
+
+export const getTextWithLinks = (text: string): TextWithLinksType => {
+  const links = linkify.find(text);
+
+  // If no links are present in the text, return the text unmodified
+  if (!links.length) {
+    return {
+      textWithLinks: text,
+      hasLinks: false
+    };
+  }
+
+  let textWithLinks = text;
+
+  // Replace the previous links in text with normalized links
+  for (const link of links) {
+    const previousLink = text.substring(link.start, link.end);
+    textWithLinks = textWithLinks.replace(previousLink, link.value);
+  }
+
+  return {
+    textWithLinks,
+    hasLinks: true
+  };
+};
+
+/**
+ * @description It checks if an asset contains suspicious info
+ * If it contains text with links inside, it contains scam info, or it is marked as NSFW,
+ * then it has suspicious info and may be a scam
+ */
+export const getScamFlag = ({
+  message,
+  scamInfo,
+  isNsfw,
+  verified,
+  messagePrefix = 'Message hidden due to suspicious content - '
+}: SuspiciousLinkPropsType): SuspiciousLinkType => {
+  if (verified) {
+    return {
+      message: '',
+      textWithLinks: '',
+      isSuspicious: false
+    };
+  }
+
+  const outputMessage = `${messagePrefix}${
+    scamInfo?.info ?? 'suspicious content'
+  }`;
+  const { textWithLinks, hasLinks } = getTextWithLinks(message);
+
+  if (hasLinks || isNsfw || scamInfo) {
+    return {
+      message: outputMessage,
+      textWithLinks,
+      isSuspicious: true
+    };
+  }
+
+  return {
+    message: '',
+    textWithLinks,
+    isSuspicious: false
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,10 +1139,10 @@
   dependencies:
     qs "6.11.2"
 
-"@multiversx/sdk-web-wallet-iframe-provider@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-iframe-provider/-/sdk-web-wallet-iframe-provider-3.0.0.tgz#65068b2fa9fc0084a2c4fb90d8e686df14258e5e"
-  integrity sha512-qEPARy3iMsmnOiRKBsAN2PCXP1l1kHpNn+8MvVFmdHC6jt5mdyKJw5Dj7CgReoLeuHwUtGDp5OGjUUGk6Cf9gg==
+"@multiversx/sdk-web-wallet-iframe-provider@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@multiversx/sdk-web-wallet-iframe-provider/-/sdk-web-wallet-iframe-provider-3.0.1.tgz#e3b9d1584f6a7b02ee1d27ff0c56bc0524c3a911"
+  integrity sha512-fXqkWPhuEiyg57JzZjgkktzRfL/pQ/7fM4wuIN8dIYUngfwEwa0uqpJy5DU90Pcqm0S2gf8whPmAeSZ7K8H5aQ==
   dependencies:
     "@types/jest" "^29.5.11"
     "@types/qs" "6.9.10"
@@ -5324,6 +5324,11 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkifyjs@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-4.3.1.tgz#1f246ebf4be040002accd1f4535b6af7c7e37898"
+  integrity sha512-DRSlB9DKVW04c4SUdGvKK5FR6be45lTU9M76JnngqPeeGDqPwYc0zdUErtsNVMtxPXgUWV4HbXbnC4sNyBxkYg==
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -6892,7 +6897,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6947,7 +6961,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7577,7 +7598,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7590,6 +7611,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Feature

Add utility for scam/suspicious content detection in asset messages, with supporting types and dependency.

### Root cause

There was no utility to programmatically detect and flag suspicious or scam content (such as links, NSFW, or scam info) in asset messages. Types for this logic were also missing, and the `linkifyjs` dependency was not present.

### Fix

- Added `getScamFlag.ts` utility in `src/utils/transactions/` to check for suspicious content in asset messages.
- Added supporting types in `src/types/suspiciousLink.types.ts`.
- Added `linkifyjs` as a dependency in `package.json` for link detection in text.

### Additional changes

N/A

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests