### PR TITLE
Add resetState for webviewProvider

### DIFF
--- a/src/providers/strategies/WebviewProviderStrategy/WebviewProviderStrategy.ts
+++ b/src/providers/strategies/WebviewProviderStrategy/WebviewProviderStrategy.ts
@@ -1,5 +1,5 @@
 import { WebviewProvider } from '@multiversx/sdk-webview-provider/out/WebviewProvider';
-import { version } from 'constants/window.constants';
+import { safeWindow, version } from 'constants/window.constants';
 import { Message, Transaction } from 'lib/sdkCore';
 import { IDAppProviderAccount } from 'lib/sdkDappUtils';
 import {
@@ -18,7 +18,16 @@ export class WebviewProviderStrategy extends BaseProviderStrategy {
 
   constructor(config?: WebviewProviderProps) {
     super(config?.address);
-    this.provider = WebviewProvider.getInstance();
+    this.provider = WebviewProvider.getInstance({
+      resetStateCallback: () => {
+        /* 
+          Used in Hub to clear storage when logging out via the hub header.
+        */
+        safeWindow.localStorage?.clear?.();
+        safeWindow.sessionStorage?.clear?.();
+      }
+    });
+
     this._login = this.provider.login.bind(this.provider);
   }
 


### PR DESCRIPTION
### Issue
- Logging out from Hub header does not clear storage

### Reproduce
- Login to any hub dApp and log out. Login again and it will be already logged in.

Issue exists on version `5.0.0-alpha.10` of sdk-dapp.

### Root cause
- Storage not being cleared on exit.

### Fix
- Clear storage on exit

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
