### PR TITLE
Fix login in hub

### DIFF
--- a/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
+++ b/src/providers/experimentalWebViewProvider/ExperimentalWebviewProvider.ts
@@ -36,7 +36,10 @@ export class ExperimentalWebviewProvider implements IDappProvider {
 
   constructor() {
     this._provider = WebviewProvider.getInstance({
-      resetStateCallback: () => store.dispatch(logoutAction())
+      resetStateCallback: () => {
+        store.dispatch(logoutAction());
+        this.logout();
+      }
     });
     this._provider.setHandshakeResponseTimeout(2000);
   }

--- a/src/providers/experimentalWebViewProvider/useInitiateExperimentalWebviewLogin.ts
+++ b/src/providers/experimentalWebViewProvider/useInitiateExperimentalWebviewLogin.ts
@@ -1,4 +1,3 @@
-import { SECOND_LOGIN_ATTEMPT_ERROR } from 'constants/errorsMessages';
 import { version } from 'constants/index';
 import { clearInitiatedLogins } from 'hooks/login/helpers';
 import { useLoginService } from 'hooks/login/useLoginService';
@@ -14,20 +13,14 @@ import {
 
 import { LoginMethodsEnum } from 'types/enums.types';
 import { getAccessTokenFromSearchParams } from 'utils/account/getAccessTokenFromSearchParams';
-import { getIsLoggedIn } from 'utils/getIsLoggedIn';
 import { ExperimentalWebviewProvider } from './ExperimentalWebviewProvider';
 
 export function useInitiateExperimentalWebviewLogin() {
-  const isLoggedIn = getIsLoggedIn();
   const dispatch = useDispatch();
   const nativeAuth = true;
   const loginService = useLoginService(nativeAuth);
 
   return async () => {
-    if (isLoggedIn) {
-      throw new Error(SECOND_LOGIN_ATTEMPT_ERROR);
-    }
-
     clearInitiatedLogins();
     dispatch(setAddress(emptyAccount.address));
     dispatch(setAccount(emptyAccount));


### PR DESCRIPTION
### Issue
- On new Hub implementation, provider doesn't work as intended due to being already logged in.

### Reproduce

Issue exists on version `4.2.2` of sdk-dapp.

### Root cause
- app loaded in brackground initiates a login

### Fix
- remove double login error

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
