### PR TITLE
Mm upgrade sdk dapp UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[5.0.0-alpha.14](https://github.com/multiversx/mx-sdk-dapp/pull/1462)] - 2025-06-24
+
+- [Updated version of "mx-sdk-dapp-ui@0.0.8"](https://github.com/multiversx/mx-sdk-dapp/pull/1461)
+
 ## [[5.0.0-alpha.13](https://github.com/multiversx/mx-sdk-dapp/pull/1477)] - 2025-06-30
 
 - [Refactor `createUiElement` to ComponentFactory](https://github.com/multiversx/mx-sdk-dapp/pull/1476)
@@ -30,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [[5.0.0-alpha.9](https://github.com/multiversx/mx-sdk-dapp/pull/1462)] - 2025-06-24
 
 - [Updated README](https://github.com/multiversx/mx-sdk-dapp/pull/1463)
-- [Updated version of "mx-sdk-dapp-ui@0.0.7"]
+- [Updated version of "mx-sdk-dapp-ui@0.0.7"](https://github.com/multiversx/mx-sdk-dapp/pull/1461)
 - [Updated webview login with version handshake](https://github.com/multiversx/mx-sdk-dapp/pull/1460)
 
 ## [[5.0.0-alpha.8](https://github.com/multiversx/mx-sdk-dapp/pull/1459)] - 2025-06-19

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "5.0.0-alpha.13",
+  "version": "5.0.0-alpha.14",
   "main": "out/index.js",
   "module": "out/index.mjs",
   "types": "out/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "bignumber.js": "9.x"
   },
   "optionalDependencies": {
-    "@multiversx/sdk-dapp-ui": ">=0.0.7"
+    "@multiversx/sdk-dapp-ui": ">=0.0.8"
   },
   "resolutions": {
     "strip-ansi": "6.0.1",


### PR DESCRIPTION
### Feature
Upgraded the `mx-sdk-dapp-ui` package to use `v0.0.8`. Also upgraded the current version of `mx-sdk-dapp`, which is now `v5.0.0-alpha.14`. The current package upgrades don't exist on `v5.0.0-alpha.13` of `mx-sdk-dapp`.

### Contains Breaking Changes

- [x] No
- [ ] Yes

### Updated CHANGELOG.md

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
