### PR TITLE
Default native auth config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[5.0.0-alpha.15](https://github.com/multiversx/mx-sdk-dapp/pull/1484)] - 2025-07-03
+
 - [Changed getDefaultNativeAuthConfig to accept an object as config](https://github.com/multiversx/mx-sdk-dapp/pull/1483)
 - [Added allowedProviders as list of strings](https://github.com/multiversx/mx-sdk-dapp/pull/1482)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Changed getDefaultNativeAuthConfig to accept an object as config](https://github.com/multiversx/mx-sdk-dapp/pull/1483)
 - [Added allowedProviders as list of strings](https://github.com/multiversx/mx-sdk-dapp/pull/1482)
 
 ## [[5.0.0-alpha.14](https://github.com/multiversx/mx-sdk-dapp/pull/1479)] - 2025-06-30

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "5.0.0-alpha.14",
+  "version": "5.0.0-alpha.15",
   "main": "out/index.js",
   "module": "out/index.mjs",
   "types": "out/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "bignumber.js": "9.x"
   },
   "optionalDependencies": {
-    "@multiversx/sdk-dapp-ui": ">=0.0.8"
+    "@multiversx/sdk-dapp-ui": ">=0.0.9"
   },
   "resolutions": {
     "strip-ansi": "6.0.1",

--- a/src/methods/initApp/initApp.ts
+++ b/src/methods/initApp/initApp.ts
@@ -74,8 +74,8 @@ export async function initApp({
     const nativeAuthConfig: NativeAuthConfigType =
       typeof dAppConfig.nativeAuth === 'boolean' &&
       dAppConfig.nativeAuth === true
-        ? getDefaultNativeAuthConfig(apiAddress)
-        : dAppConfig.nativeAuth;
+        ? getDefaultNativeAuthConfig({ apiAddress })
+        : getDefaultNativeAuthConfig(dAppConfig.nativeAuth);
 
     setNativeAuthConfig(nativeAuthConfig);
   }

--- a/src/services/nativeAuth/methods/getDefaultNativeAuthConfig.ts
+++ b/src/services/nativeAuth/methods/getDefaultNativeAuthConfig.ts
@@ -1,12 +1,22 @@
+import { networkSelector } from 'store/selectors';
+import { getState } from 'store/store';
 import { getWindowLocation } from 'utils/window/getWindowLocation';
+import { NativeAuthConfigType } from '../nativeAuth.types';
 
-export const getDefaultNativeAuthConfig = (
-  apiAddress = 'https://api.multiversx.com'
-) => {
+const DEFAULT_API_ADDRESS = 'https://api.multiversx.com';
+
+const DEFAULT_EXPIRY_SECONDS = 60 * 60 * 24; // one day
+const DEFAULT_TOKEN_EXPIRATION_TOAST_WARNING_SECONDS = 5 * 60; // five minutes
+
+export const getDefaultNativeAuthConfig = (config?: NativeAuthConfigType) => {
+  const network = networkSelector(getState());
+
   return {
-    origin: getWindowLocation().origin,
-    apiAddress,
-    expirySeconds: 60 * 60 * 24, // one day
-    tokenExpirationToastWarningSeconds: 5 * 60 // five minutes
+    origin: config?.origin || getWindowLocation().origin,
+    apiAddress: config?.apiAddress || network.apiAddress || DEFAULT_API_ADDRESS,
+    expirySeconds: config?.expirySeconds || DEFAULT_EXPIRY_SECONDS,
+    tokenExpirationToastWarningSeconds:
+      config?.tokenExpirationToastWarningSeconds ||
+      DEFAULT_TOKEN_EXPIRATION_TOAST_WARNING_SECONDS
   };
 };

--- a/src/utils/account/index.ts
+++ b/src/utils/account/index.ts
@@ -1,3 +1,4 @@
 export * from './fetchAccount';
 export * from './refreshAccount';
 export * from './trimUsernameDomain';
+export * from './refreshNativeAuthTokenLogin';

--- a/src/utils/account/refreshNativeAuthTokenLogin.ts
+++ b/src/utils/account/refreshNativeAuthTokenLogin.ts
@@ -4,8 +4,6 @@ import { nativeAuth } from 'services/nativeAuth';
 import { getDefaultNativeAuthConfig } from 'services/nativeAuth/methods/getDefaultNativeAuthConfig';
 import { NativeAuthConfigType } from 'services/nativeAuth/nativeAuth.types';
 import { setTokenLogin } from 'store/actions/loginInfo/loginInfoActions';
-import { networkSelector } from 'store/selectors/networkSelectors';
-import { getState } from 'store/store';
 
 /**
  * Use this function if you support multiple networks with network switching
@@ -22,10 +20,7 @@ export const refreshNativeAuthTokenLogin = async ({
   nativeAuthClientConfig?: NativeAuthConfigType;
 }): Promise<string | null> => {
   const { address } = getAccount();
-  const network = networkSelector(getState());
-  const defaultNativeAuthConfig = getDefaultNativeAuthConfig(
-    network.apiAddress
-  );
+  const defaultNativeAuthConfig = getDefaultNativeAuthConfig();
 
   const nativeAuthClient = nativeAuth(
     nativeAuthClientConfig || defaultNativeAuthConfig

--- a/src/utils/window/getWindowLocation.ts
+++ b/src/utils/window/getWindowLocation.ts
@@ -9,7 +9,13 @@ type GetWindowLocationType = {
 };
 
 export const getWindowLocation = (): GetWindowLocationType => {
-  const isAvailable = isWindowAvailable();
+  let isAvailable: boolean;
+
+  try {
+    isAvailable = isWindowAvailable();
+  } catch (_err) {
+    isAvailable = false;
+  }
 
   if (!isAvailable) {
     return {

--- a/src/utils/window/getWindowLocation.ts
+++ b/src/utils/window/getWindowLocation.ts
@@ -13,7 +13,7 @@ export const getWindowLocation = (): GetWindowLocationType => {
 
   try {
     isAvailable = isWindowAvailable();
-  } catch (_err) {
+  } catch (_error) {
     isAvailable = false;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,14 +1044,14 @@
     axios "^1.7.4"
     bip39 "3.1.0"
 
-"@multiversx/sdk-dapp-ui@>=0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@multiversx/sdk-dapp-ui/-/sdk-dapp-ui-0.0.7.tgz#6e8914c49fb6a34dcae3087a7fc05db2d76f46e5"
-  integrity sha512-5bTTY62JYvb9Zo0Z/WBl6ZxMjzvm4lF9K0Ntq9IAG8a0E9nDs7zcWc2gOB8vXYvHN0CL6WINXIqNT1da9KtzBw==
+"@multiversx/sdk-dapp-ui@>=0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@multiversx/sdk-dapp-ui/-/sdk-dapp-ui-0.0.9.tgz#280083c2c0b8e8eb206c2f2eef39663bf57464fd"
+  integrity sha512-Sz/5EUoHKp2JOryITdubXfUWzbnTiGMNzBOK2nHWnV5auoEwsCptXygxZzvymog2ztpwEvwKCiOzCKlhYSpYfA==
   dependencies:
     "@fortawesome/fontawesome-svg-core" ">= 6.7.2"
     "@fortawesome/free-solid-svg-icons" ">= 6.7.2"
-    "@multiversx/sdk-dapp-utils" ">= 1.0.4"
+    "@rollup/plugin-image" "^3.0.3"
     "@stencil/react-output-target" "0.8.2"
     classnames ">= 2.5.1"
     lodash.inrange "^3.3.0"
@@ -1059,7 +1059,7 @@
     qrcode ">= 1.5.4"
     sass-embedded "^1.85.1"
 
-"@multiversx/sdk-dapp-utils@>= 1.0.4", "@multiversx/sdk-dapp-utils@^2.x":
+"@multiversx/sdk-dapp-utils@^2.x":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@multiversx/sdk-dapp-utils/-/sdk-dapp-utils-2.0.0.tgz#15cae568ae5d25ea2ac12c3793d52d18db5ac1fe"
   integrity sha512-NcaQUgXrjDqjKJgbUj1eM11ID7sDJRVFamjEA/VO4qquP8jBOrSeW0ltvppHElZGC/A14tNDERPbZQkrLIa2KQ==
@@ -1329,6 +1329,23 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@rollup/plugin-image@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-image/-/plugin-image-3.0.3.tgz#025b557180bae20f2349ff5130ef2114169feaac"
+  integrity sha512-qXWQwsXpvD4trSb8PeFPFajp8JLpRtqqOeNYRUKnEQNHm7e5UP7fuSRcbjQAJ7wDZBbnJvSdY5ujNBQd9B1iFg==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    mini-svg-data-uri "^1.4.4"
+
+"@rollup/pluginutils@^5.0.1":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.2.0.tgz#eac25ca5b0bdda4ba735ddaca5fbf26bd435f602"
+  integrity sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^4.0.2"
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
@@ -1579,7 +1596,7 @@
   dependencies:
     "@types/ms" "*"
 
-"@types/estree@^1.0.6":
+"@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -3745,6 +3762,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5525,6 +5547,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mini-svg-data-uri@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz#8ab0aabcdf8c29ad5693ca595af19dd2ead09939"
+  integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -5999,6 +6026,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
 pino-abstract-transport@v0.5.0:
   version "0.5.0"
@@ -6916,16 +6948,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6980,14 +7003,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7617,7 +7633,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7630,15 +7646,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Feature

- Update the default native auth config logic to accept an object as config.
- Add support for `allowedProviders` as a list of strings.
- Update to `@multiversx/sdk-dapp-ui@0.0.9`.
- Moved refreshNativeAuthTokenLogin from core to utils/account 

### Root cause

- The previous implementation of `getDefaultNativeAuthConfig` only accepted a string (`apiAddress`), limiting flexibility.
- `allowedProviders` previously required a more complex structure, making it harder to specify allowed providers simply.

### Fix

- Changed `getDefaultNativeAuthConfig` to accept an object, allowing for more flexible configuration (origin, apiAddress, expirySeconds, etc).
- Updated `allowedProviders` to accept a list of provider type strings, simplifying usage and configuration.
- Upgraded `@multiversx/sdk-dapp-ui` to version `0.0.9`.

### Additional changes

- Moved `refreshNativeAuthTokenLogin` from core to `utils/account`.
- Improved window location utility for better error handling.
- Updated documentation and usage examples in the README.
- Bumped package version to `5.0.0-alpha.15`.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests