### PR TITLE
Enhance account API calls to accept custom headers

### DIFF
--- a/src/apiCalls/account/getAccountFromApi.ts
+++ b/src/apiCalls/account/getAccountFromApi.ts
@@ -6,33 +6,38 @@ import { AccountType } from 'types/account.types';
 
 export const accountFetcher = ({
   address,
-  baseURL
+  baseURL,
+  headers
 }: {
   address: string | null;
   baseURL: string;
+  headers?: Record<string, string>;
 }) => {
   const apiAddress = getCleanApiAddress(baseURL);
   const url = `${apiAddress}/${ACCOUNTS_ENDPOINT}/${address}?withGuardianInfo=true`;
   // we need to get it with an axios instance because of cross-window user interaction issues
   return axiosInstance.get(url, {
     baseURL: apiAddress,
-    timeout: TIMEOUT
+    timeout: TIMEOUT,
+    headers
   });
 };
 
 export const getAccountFromApi = async ({
   address,
-  baseURL
+  baseURL,
+  headers
 }: {
   address?: string;
   baseURL: string;
+  headers?: Record<string, string>;
 }) => {
   if (!address) {
     return null;
   }
 
   try {
-    const { data } = await accountFetcher({ address, baseURL });
+    const { data } = await accountFetcher({ address, baseURL, headers });
     return data as AccountType;
   } catch (_err) {
     console.error('error fetching configuration for ', address);

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -8,6 +8,7 @@ export interface NetworkType {
   gasPerDataByte: string;
   walletAddress: string;
   apiAddress: string;
+  headers?: Record<string, string>;
   explorerAddress: string;
   apiTimeout: string;
   xAliasAddress?: string;


### PR DESCRIPTION
- Updated accountFetcher and getAccountFromApi functions to include an optional headers parameter for custom HTTP headers.
- Modified NetworkType interface to include headers property for better type definition.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
