### PR TITLE
Fix cross-window initialization

### DIFF
--- a/src/providers/helpers/clearInitiatedLogins.ts
+++ b/src/providers/helpers/clearInitiatedLogins.ts
@@ -16,7 +16,8 @@ export const clearInitiatedLogins = (
       case ProviderTypeEnum.crossWindow: {
         const crossWindowProvider = CrossWindowProvider.getInstance();
         if (crossWindowProvider.isInitialized()) {
-          crossWindowProvider.dispose();
+          // Clean up the crossWindowProvider state without triggering a full logout.
+          crossWindowProvider.onDestroy();
         }
         break;
       }


### PR DESCRIPTION
### Issue
- Opening xPortal from a previous initialization of Web wallet, it will reopen the wallet into a new tab in order to execute a logout.

### Reproduce
- click on web wallet
- close tab
- open xPortal

Issue exists on version `5.0.0-alpha.18` of sdk-dapp.

### Root cause
- it forces a logout

### Fix
- reset the initialization instead of executing a LOGOUT_REQUEST

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
