### PR TITLE
Add set account provider on create

### DIFF
--- a/src/providers/ProviderFactory.ts
+++ b/src/providers/ProviderFactory.ts
@@ -1,7 +1,6 @@
 import { IframeLoginTypes } from '@multiversx/sdk-web-wallet-iframe-provider/out/constants';
 import { LedgerIdleStateManager } from 'managers/internal/LedgerIdleStateManager/LedgerIdleStateManager';
 import { getAddress } from 'methods/account/getAddress';
-import { getIsLoggedIn } from 'methods/account/getIsLoggedIn';
 import {
   CrossWindowProviderStrategy,
   ExtensionProviderStrategy,
@@ -122,12 +121,8 @@ export class ProviderFactory {
 
     await createdProvider.init();
 
-    const isLoggedIn = getIsLoggedIn();
     const dappProvider = new DappProvider(createdProvider);
-
-    if (isLoggedIn) {
-      setAccountProvider(dappProvider);
-    }
+    setAccountProvider(dappProvider);
 
     const shouldClearInitiatedLogins = (
       [


### PR DESCRIPTION
### Issue
- cancelling the login request while CrossWindow tab is active, it does not send the LOGOUT_REQUEST

### Reproduce

Issue exists on version `5.0.0` of sdk-dapp.

### Root cause
- accountProvider is set only after login in which until that, emptyProvider is in place.

### Fix
- set accountProvider on ProviderFactory.create

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
