### PR TITLE
Fixed init app double init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed init app double init](https://github.com/multiversx/mx-sdk-dapp/pull/1513)
+
 ## [[5.0.3](https://github.com/multiversx/mx-sdk-dapp/pull/1509)] - 2025-07-15
 
 - [Updated bundler to use esm](https://github.com/multiversx/mx-sdk-dapp/pull/1508)

--- a/src/methods/initApp/initApp.ts
+++ b/src/methods/initApp/initApp.ts
@@ -41,6 +41,7 @@ const defaultInitAppProps = {
  * @internal
  */
 let isAppInitialized = false;
+let isInitializing = false;
 
 /**
  * Initializes the dApp with the given configuration.
@@ -59,6 +60,12 @@ export async function initApp({
   dAppConfig,
   customProviders
 }: InitAppType) {
+  if (isInitializing) {
+    return;
+  }
+
+  isInitializing = true;
+
   const defaultTheme = dAppConfig?.theme ?? ThemesEnum.dark;
   await defineCustomElements();
 
@@ -127,4 +134,5 @@ export async function initApp({
   }
 
   isAppInitialized = true;
+  isInitializing = false;
 }


### PR DESCRIPTION
### Issue
initApp can be called twice while firts call does not finis

### Reproduce
call initApp in useEffect

### Fix
Add a flag to prevent execution while init is in progress

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
