### PR TITLE
Fix login with token from hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed token login from hub](https://github.com/multiversx/mx-sdk-dapp/pull/1520)
 - [Added cjs support for esbuild](https://github.com/multiversx/mx-sdk-dapp/pull/1517)
 
 ## [[5.0.4](https://github.com/multiversx/mx-sdk-dapp/pull/1516)] - 2025-07-16

--- a/src/providers/DappProvider/helpers/login/login.ts
+++ b/src/providers/DappProvider/helpers/login/login.ts
@@ -3,6 +3,7 @@ import { getNetworkConfig } from 'methods/network/getNetworkConfig';
 import { trackTransactions } from 'methods/trackTransactions/trackTransactions';
 import { IProvider } from 'providers/types/providerFactory.types';
 import { nativeAuth } from 'services/nativeAuth';
+import { decodeNativeAuthToken } from 'services/nativeAuth/helpers/decodeNativeAuthToken';
 import { NativeAuthConfigType } from 'services/nativeAuth/nativeAuth.types';
 import { setTokenLogin } from 'store/actions/loginInfo/loginInfoActions';
 import { nativeAuthConfigSelector } from 'store/selectors';
@@ -66,11 +67,16 @@ async function loginWithNativeToken({
     return null;
   }
 
-  const nativeAuthToken = nativeAuthClient.getToken({
-    address,
-    token: loginToken,
-    signature
-  });
+  // nativeAuthToken received from hub login
+  const decodedToken = decodeNativeAuthToken(loginResult?.accessToken);
+
+  const nativeAuthToken = decodedToken
+    ? loginResult.accessToken
+    : nativeAuthClient.getToken({
+        address,
+        token: loginToken,
+        signature
+      });
 
   setTokenLogin({
     loginToken,

--- a/src/providers/types/providerFactory.types.ts
+++ b/src/providers/types/providerFactory.types.ts
@@ -8,6 +8,7 @@ export interface IProvider<T extends ProviderType = ProviderType>
     signature: string;
     multisig?: string;
     impersonate?: string;
+    accessToken?: string;
     [key: string]: unknown;
   }>;
   logout: () => Promise<boolean>;


### PR DESCRIPTION
### Issue
- logging in from hub has invalid signature

### Reproduce
- login to dApp from hub

Issue exists on version `5.0.4` of sdk-dapp.

### Root cause
- nativeAuthToken sent from hub is being regenerated and used with different signature

### Fix

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
