### PR TITLE
Fixed transactions pending after completed session

### DIFF
--- a/src/store/selectors/transactionsSelector.ts
+++ b/src/store/selectors/transactionsSelector.ts
@@ -74,9 +74,10 @@ export const pendingTransactionsSelector = ({
 }: StoreType): SignedTransactionType[] => {
   const pendingTransactions: SignedTransactionType[] = [];
 
-  Object.values(state).forEach(({ transactions }) => {
+  Object.values(state).forEach(({ transactions, status: sessionStatus }) => {
     transactions.forEach((transaction) => {
       if (
+        sessionStatus === TransactionBatchStatusesEnum.sent &&
         transaction.status &&
         [
           TransactionServerStatusesEnum.pending,


### PR DESCRIPTION
### Issue
When sending a batch of transactions, if one transaction failed, the session would complete but the remaining transactions would remain stuck in a pending state. This also caused the buttons to stay disabled, preventing users from retrying.

### Fix
Once the session completes, none of remaining transactions are counted as pending anymore.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
