### PR TITLE
Fix duplicate calls to getTransactionsByHashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 - [Fixed multiple calls to /transactions endpoint on tracking transactions](https://github.com/multiversx/mx-sdk-dapp/pull/1583)
 
 ## [[5.1.7](https://github.com/multiversx/mx-sdk-dapp/pull/1582)] - 2025-09-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed multiple calls to /transactions endpoint on tracking transactions](https://github.com/multiversx/mx-sdk-dapp/pull/1583)
+
+
 ## [[5.1.6](https://github.com/multiversx/mx-sdk-dapp/pull/1580)] - 2025-09-22
 
 - [Added customToast `hasCloseButton` option](https://github.com/multiversx/mx-sdk-dapp/pull/1579)

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "protobufjs": "^7.2.6"
   },
   "optionalDependencies": {
-    "@multiversx/sdk-dapp-ui": ">=0.0.29"
+    "@multiversx/sdk-dapp-ui": "0.0.30"
   },
   "resolutions": {
     "strip-ansi": "6.0.1",

--- a/src/managers/internal/ToastManager/ToastManager.ts
+++ b/src/managers/internal/ToastManager/ToastManager.ts
@@ -72,14 +72,24 @@ export class ToastManager {
         { toasts, transactions },
         { toasts: prevToasts, transactions: prevTransactions }
       ) => {
-        if (
-          !isEqual(prevToasts.transactionToasts, toasts.transactionToasts) ||
-          !isEqual(prevTransactions, transactions)
-        ) {
-          await this.updateTransactionToastsList();
+        const newToastsWereCreated = !isEqual(
+          prevToasts.transactionToasts,
+          toasts.transactionToasts
+        );
+        const checkBatchHasNewData = !isEqual(prevTransactions, transactions);
+
+        if (newToastsWereCreated || checkBatchHasNewData) {
+          await this.updateTransactionToastsList({
+            skipFetchingTransactions: checkBatchHasNewData // transactions were already fetched by `checkBatch`
+          });
         }
 
-        if (!isEqual(prevToasts.customToasts, toasts.customToasts)) {
+        const newCustomToastsWereCreated = !isEqual(
+          prevToasts.customToasts,
+          toasts.customToasts
+        );
+
+        if (newCustomToastsWereCreated) {
           await this.updateCustomToastList();
         }
       }
@@ -138,7 +148,9 @@ export class ToastManager {
     return toastId;
   }
 
-  private async updateTransactionToastsList() {
+  private async updateTransactionToastsList(props?: {
+    skipFetchingTransactions?: boolean;
+  }) {
     const {
       toasts: toastList,
       transactions: transactionsSessions,
@@ -149,7 +161,8 @@ export class ToastManager {
       await createToastsFromTransactions({
         toastList,
         transactionsSessions,
-        account
+        account,
+        skipFetchingTransactions: props?.skipFetchingTransactions
       });
 
     this.transactionToasts = [

--- a/src/managers/internal/ToastManager/helpers/createToastsFromTransactions.ts
+++ b/src/managers/internal/ToastManager/helpers/createToastsFromTransactions.ts
@@ -23,13 +23,15 @@ interface CreateToastsFromTransactionsParamsType {
   transactionsSessions: Record<string, SessionTransactionType>;
   account: AccountSliceType;
   existingCompletedTransactions?: ITransactionToast[];
+  skipFetchingTransactions?: boolean;
 }
 
 export const createToastsFromTransactions = async ({
   toastList,
   transactionsSessions,
   account,
-  existingCompletedTransactions = []
+  existingCompletedTransactions = [],
+  skipFetchingTransactions = false
 }: CreateToastsFromTransactionsParamsType): Promise<CreateToastsFromTransactionsReturnType> => {
   const pendingTransactionToasts: ITransactionToast[] = [];
   const completedTransactionToasts: ITransactionToast[] = [
@@ -51,7 +53,8 @@ export const createToastsFromTransactions = async ({
       transactions,
       address: account.address,
       explorerAddress,
-      egldLabel
+      egldLabel,
+      skipFetchingTransactions
     });
 
     const isTimedOut = getIsTransactionTimedOut(status);

--- a/src/utils/transactions/getTransactionsHistory/helpers/mapServerTransactionsToListItems.ts
+++ b/src/utils/transactions/getTransactionsHistory/helpers/mapServerTransactionsToListItems.ts
@@ -12,6 +12,7 @@ interface IMapServerTransactionsToListItemsParams {
   address: string;
   explorerAddress: string;
   egldLabel: string;
+  skipFetchingTransactions?: boolean;
 }
 
 const sortTransactionsByTimestamp = (transactions: ITransactionListItem[]) =>
@@ -21,7 +22,8 @@ export const mapServerTransactionsToListItems = async ({
   transactions,
   address,
   explorerAddress,
-  egldLabel
+  egldLabel,
+  skipFetchingTransactions = false
 }: IMapServerTransactionsToListItemsParams): Promise<
   ITransactionListItem[]
 > => {
@@ -41,7 +43,13 @@ export const mapServerTransactionsToListItems = async ({
     return sortTransactionsByTimestamp(cachedTransactions);
   }
 
-  const newTransactions = await getServerTransactionsByHashes(hashesToFetch);
+  const newTransactions: ServerTransactionType[] = skipFetchingTransactions
+    ? transactions.map((tx) => ({
+        // casting is correct since store transaction was replaced with fetchedserver transaction
+        ...(tx as unknown as ServerTransactionType),
+        txHash: tx.hash
+      }))
+    : await getServerTransactionsByHashes(hashesToFetch);
 
   const retrievedHashes = newTransactions.map((tx) => tx.txHash);
   const missingHashes = hashesToFetch.filter(
@@ -74,6 +82,16 @@ export const mapServerTransactionsToListItems = async ({
     newTransactions.push(...pendingDummyTransactions);
   }
 
+  const uniqueTransactionsMap = new Map<string, ITransactionListItem>();
+
+  cachedTransactions.forEach((item) => {
+    const key = item.hash;
+    if (!key) {
+      return;
+    }
+    uniqueTransactionsMap.set(String(key), item);
+  });
+
   newTransactions.forEach((transaction) => {
     const transactionListItem = mapTransactionToListItem({
       transaction,
@@ -89,8 +107,10 @@ export const mapServerTransactionsToListItems = async ({
       });
     }
 
-    cachedTransactions.push(transactionListItem);
+    uniqueTransactionsMap.set(transaction.txHash, transactionListItem);
   });
 
-  return sortTransactionsByTimestamp(cachedTransactions);
+  return sortTransactionsByTimestamp(
+    Array.from(uniqueTransactionsMap.values())
+  );
 };

--- a/src/utils/transactions/getTransactionsHistory/helpers/mapServerTransactionsToListItems.ts
+++ b/src/utils/transactions/getTransactionsHistory/helpers/mapServerTransactionsToListItems.ts
@@ -45,7 +45,7 @@ export const mapServerTransactionsToListItems = async ({
 
   const newTransactions: ServerTransactionType[] = skipFetchingTransactions
     ? transactions.map((tx) => ({
-        // casting is correct since store transaction was replaced with fetchedserver transaction
+        // casting is correct since store transaction was replaced with fetched server transaction
         ...(tx as unknown as ServerTransactionType),
         txHash: tx.hash
       }))


### PR DESCRIPTION
### Issue
Too many calls are made to /transactions endpoint when tracking transactions

### Reproduce
Go to https://devnet.template-dapp.multiversx.com/ and make a Swap & Lock action and look in the Network tab

### Root cause
Both [mapServerTransactionsToListItems](https://github.com/multiversx/mx-sdk-dapp/blob/e53269635eb28735fcb8b32f6fbedd49fbfe226c/src/utils/transactions/getTransactionsHistory/helpers/mapServerTransactionsToListItems.ts#L44) and [checkBatch](https://github.com/multiversx/mx-sdk-dapp/blob/e53269635eb28735fcb8b32f6fbedd49fbfe226c/src/methods/trackTransactions/helpers/checkTransactionStatus/checkBatch.ts#L130) were calling [getServerTransactionsByHashes](https://github.com/multiversx/mx-sdk-dapp/blob/e53269635eb28735fcb8b32f6fbedd49fbfe226c/src/apiCalls/transactions/getServerTransactionsByHashes.ts#L7C14-L7C43). This happend concurently when either[ toasts changed](https://github.com/multiversx/mx-sdk-dapp/blob/e53269635eb28735fcb8b32f6fbedd49fbfe226c/src/managers/internal/ToastManager/ToastManager.ts#L76) or a websocket event occured that triggered a[ transaction status change](https://github.com/multiversx/mx-sdk-dapp/blob/e53269635eb28735fcb8b32f6fbedd49fbfe226c/src/managers/internal/ToastManager/ToastManager.ts#L77) in the store. This made API calls with the same arguments be executed twice or three times in a row and subsequently trigger unnecessary UI updates in the toasts.

### Fix
Allow skipping refetch of transactions in `mapServerTransactionsToListItems` if they were already fetched in the store

### Additional changes
Upgrade sdk-dapp-ui to v.0.0.30

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
