### PR TITLE
Added session callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,14 @@ const options: TransactionManagerTrackOptionsType = {
   sessionInformation: {
     // `undefined` by default. Use to perform additional actions based on the session information
     stakeAmount: '1000000000000000000000000'
+  },
+  onSuccess: async(sessionId) => { // optional
+    // will be executed when the currentsession is successful
+    // does not override the global onSuccess callback set in the initApp method
+    console.log('Session successful', sessionId);
+  },
+  onFail: async(sessionId) => { // optional
+    console.log('Session failed', sessionId);
   }
 };
 

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ const options: TransactionManagerTrackOptionsType = {
     stakeAmount: '1000000000000000000000000'
   },
   onSuccess: async(sessionId) => { // optional
-    // will be executed when the currentsession is successful
+    // will be executed when the current session is successful
     // does not override the global onSuccess callback set in the initApp method
     console.log('Session successful', sessionId);
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "main": "out/index.cjs",
   "module": "out/index.mjs",
   "types": "out/index.d.ts",

--- a/src/managers/TransactionManager/TransactionManager.types.ts
+++ b/src/managers/TransactionManager/TransactionManager.types.ts
@@ -1,4 +1,5 @@
 import { CreateTransactionsSessionType } from 'store/actions/transactions/transactionsActions';
+import { SessionCallbacksType } from './helpers/sessionCallbacks';
 
 export type TransactionManagerTrackOptionsType = {
   disableToasts?: boolean;
@@ -10,4 +11,12 @@ export type TransactionManagerTrackOptionsType = {
    * Optional custom information to be associated with the transaction session.
    */
   sessionInformation?: CreateTransactionsSessionType['sessionInformation'];
+  /**
+   * Callback to be executed when the specific session id is successful
+   */
+  onSuccess?: SessionCallbacksType['onSuccess'];
+  /**
+   * Callback to be executed when the specific session id is failed
+   */
+  onFail?: SessionCallbacksType['onFail'];
 };

--- a/src/managers/TransactionManager/helpers/sessionCallbacks.ts
+++ b/src/managers/TransactionManager/helpers/sessionCallbacks.ts
@@ -1,18 +1,35 @@
-export const sessionCallbacksMap: SessionCallbacksType = {};
+const sessionCallbacksMap: Record<string, SessionCallbacksType> = {};
 
-type SessionCallbacksType = {
+const genericCallbacksMap: SessionCallbacksType = {};
+
+export type SessionCallbacksType = {
   onSuccess?: (sessionId: string) => Promise<void>;
   onFail?: (sessionId: string) => Promise<void>;
 };
 
-export const registerSessionCallbacks = ({
+export const getCallbacks = (sessionId?: string): SessionCallbacksType => {
+  if (sessionId != null && sessionId in sessionCallbacksMap) {
+    return sessionCallbacksMap[sessionId];
+  }
+  return genericCallbacksMap;
+};
+
+export const registerCallbacks = ({
   onSuccess,
-  onFail
-}: SessionCallbacksType) => {
+  onFail,
+  sessionId
+}: SessionCallbacksType & { sessionId?: string }) => {
+  let map = genericCallbacksMap;
+
+  if (sessionId != null) {
+    sessionCallbacksMap[sessionId] = sessionCallbacksMap[sessionId] ?? {};
+    map = sessionCallbacksMap[sessionId];
+  }
+
   if (onSuccess != null) {
-    sessionCallbacksMap.onSuccess = onSuccess;
+    map.onSuccess = onSuccess;
   }
   if (onFail != null) {
-    sessionCallbacksMap.onFail = onFail;
+    map.onFail = onFail;
   }
 };

--- a/src/methods/initApp/initApp.ts
+++ b/src/methods/initApp/initApp.ts
@@ -2,7 +2,7 @@ import { safeWindow } from 'constants/window.constants';
 import { defineCustomElements } from 'lib/sdkDappUi';
 import { ToastManager } from 'managers/internal/ToastManager/ToastManager';
 import { LogoutManager } from 'managers/LogoutManager/LogoutManager';
-import { registerSessionCallbacks } from 'managers/TransactionManager/helpers/sessionCallbacks';
+import { registerCallbacks } from 'managers/TransactionManager/helpers/sessionCallbacks';
 import { restoreProvider } from 'providers/helpers/restoreProvider';
 import { ProviderFactory } from 'providers/ProviderFactory';
 import { ICustomProvider } from 'providers/types/providerFactory.types';
@@ -149,7 +149,7 @@ export async function initApp({
       await registerWebsocketListener(account.address);
       trackTransactions();
       LogoutManager.getInstance().init();
-      registerSessionCallbacks({
+      registerCallbacks({
         onSuccess: dAppConfig.transactionTracking?.onSuccess,
         onFail: dAppConfig.transactionTracking?.onFail
       });

--- a/src/methods/trackTransactions/helpers/checkTransactionStatus/runSessionCallbacks.ts
+++ b/src/methods/trackTransactions/helpers/checkTransactionStatus/runSessionCallbacks.ts
@@ -1,7 +1,7 @@
-import { sessionCallbacksMap } from 'managers/TransactionManager/helpers/sessionCallbacks';
+import { getCallbacks } from 'managers/TransactionManager/helpers/sessionCallbacks';
 import { TransactionBatchStatusesEnum } from 'types/enums.types';
 
-interface runSessionCallbacksPropsType {
+interface RunSessionCallbacksPropsType {
   sessionId: string;
   status?: TransactionBatchStatusesEnum | null;
 }
@@ -9,22 +9,22 @@ interface runSessionCallbacksPropsType {
 export async function runSessionCallbacks({
   sessionId,
   status
-}: runSessionCallbacksPropsType) {
-  const { onSuccess, onFail } = sessionCallbacksMap;
+}: RunSessionCallbacksPropsType) {
+  const callbacks = getCallbacks(sessionId);
 
-  if (!onSuccess || !onFail || status == null) {
+  if (!callbacks.onSuccess || !callbacks.onFail || status == null) {
     return;
   }
 
   switch (status) {
     case TransactionBatchStatusesEnum.success:
-      await onSuccess?.(sessionId);
+      await callbacks?.onSuccess?.(sessionId);
       break;
     case TransactionBatchStatusesEnum.fail:
     case TransactionBatchStatusesEnum.cancelled:
     case TransactionBatchStatusesEnum.timedOut:
     case TransactionBatchStatusesEnum.invalid:
-      await onFail?.(sessionId);
+      await callbacks?.onFail?.(sessionId);
       break;
   }
 }

--- a/src/methods/trackTransactions/helpers/checkTransactionStatus/runSessionCallbacks.ts
+++ b/src/methods/trackTransactions/helpers/checkTransactionStatus/runSessionCallbacks.ts
@@ -12,7 +12,7 @@ export async function runSessionCallbacks({
 }: RunSessionCallbacksPropsType) {
   const callbacks = getCallbacks(sessionId);
 
-  if (!callbacks.onSuccess || !callbacks.onFail || status == null) {
+  if (status == null) {
     return;
   }
 


### PR DESCRIPTION
### Issue
Users cannot set callbacks for a specific transaction session

### Reproduce
Registering callbacks after `initApp` using TransactionManager.registerCallbacks` is always overwriting the global callbacks function

### Root cause
Both `initApp` and `TransactionManager.registerCallbacks` use the same object for reference

### Fix
Allow setting the callbacks by referencing the `sessionId`

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
