### PR TITLE
Fix inherit cross window provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[5.2.4](https://github.com/multiversx/mx-sdk-dapp/pull/1606)] - 2025-10-03
+## [[5.2.4](https://github.com/multiversx/mx-sdk-dapp/pull/1605)] - 2025-10-03
 
-- [Fixed clearing cross-window initiated logins](https://github.com/multiversx/mx-sdk-dapp/pull/1605)
+- [Fixed clearing cross-window initiated logins](https://github.com/multiversx/mx-sdk-dapp/pull/1606)
 - [Fixed explorer links not working in transactions table](https://github.com/multiversx/mx-sdk-dapp/pull/1604)
 
 ## [[5.2.3](https://github.com/multiversx/mx-sdk-dapp/pull/1601)] - 2025-09-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[5.2.4](https://github.com/multiversx/mx-sdk-dapp/pull/1606)] - 2025-10-03
+
+- [Fixed clearing cross-window initiated logins](https://github.com/multiversx/mx-sdk-dapp/pull/1605)
 - [Fixed explorer links not working in transactions table](https://github.com/multiversx/mx-sdk-dapp/pull/1604)
 
 ## [[5.2.3](https://github.com/multiversx/mx-sdk-dapp/pull/1601)] - 2025-09-29

--- a/src/providers/ProviderFactory.ts
+++ b/src/providers/ProviderFactory.ts
@@ -1,3 +1,4 @@
+import { CrossWindowProvider } from 'lib/sdkWebWalletCrossWindowProvider';
 import { LedgerIdleStateManager } from 'managers/internal/LedgerIdleStateManager/LedgerIdleStateManager';
 import { getAddress } from 'methods/account/getAddress';
 import {
@@ -113,11 +114,15 @@ export class ProviderFactory {
     const dappProvider = new DappProvider(createdProvider);
     setAccountProvider(dappProvider);
 
-    const shouldClearInitiatedLogins = ProviderTypeEnum.crossWindow === type;
+    const shouldClearInitiatedLogins =
+      'provider' in createdProvider &&
+      createdProvider.provider instanceof CrossWindowProvider;
 
     // Clear initiated logins and skip the login method if it's crossWindow or metamask
     clearInitiatedLogins(
-      shouldClearInitiatedLogins ? { skipLoginMethod: type } : null
+      shouldClearInitiatedLogins
+        ? { skipLoginMethod: ProviderTypeEnum.crossWindow }
+        : null
     );
 
     return dappProvider;


### PR DESCRIPTION
### Issue
Unable to create new custom providers that implement `CrossWindowStrategy`

### Reproduce
Do a new provider like

```
import { CrossWindowProviderStrategy } from '@multiversx/sdk-dapp/out/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy';

export class CustomProvider extends CrossWindowProviderStrategy {
  getType() {
    return 'customProvider';
  }
}
```

### Root cause
CrossWindowProvider gets reset and does not login

### Fix
Detect constructor and if constructor is CrossWindow, skip clearing initiated login

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
