### PR TITLE
Fixed unable to sign transactions on web wallet with walletconnect provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[v4.3.6](https://github.com/multiversx/mx-sdk-dapp/pull/1610)] - 2025-10-08
+
+- [Fixed walletconnect login and sign transactions](https://github.com/multiversx/mx-sdk-dapp/pull/1610)
+
 ## [[v4.3.5](https://github.com/multiversx/mx-sdk-dapp/pull/1607)] - 2025-10-06
 
 - [Added ability to bypass sender validation for specific origins in `checkIsValidSender`](https://github.com/multiversx/mx-sdk-dapp/pull/1607)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[v4.3.6](https://github.com/multiversx/mx-sdk-dapp/pull/1610)] - 2025-10-08
+## [[v4.3.6](https://github.com/multiversx/mx-sdk-dapp/pull/1609)] - 2025-10-08
 
-- [Fixed walletconnect login and sign transactions](https://github.com/multiversx/mx-sdk-dapp/pull/1610)
+- [Fixed walletconnect login and sign transactions](https://github.com/multiversx/mx-sdk-dapp/pull/1609)
 
 ## [[v4.3.5](https://github.com/multiversx/mx-sdk-dapp/pull/1607)] - 2025-10-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "GPL-3.0-or-later",
@@ -18,7 +18,7 @@
     "build": "rimraf dist && node esbuild.js && npm run build:esm-types && npm run build:cjs-types && cp package.json dist && cp README.md dist",
     "publish-package": "npm run test && npm run build && cd dist && npm publish",
     "publish-package-next": "npm run test && npm run build && cd dist && npm publish --tag next",
-    "unpublish-verdaccio": "npm unpublish @multiversx/sdk-dapp@4.3.5-alpha.1 --registry http://localhost:4873",
+    "unpublish-verdaccio": "npm unpublish @multiversx/sdk-dapp@4.3.6 --registry http://localhost:4873",
     "publish-verdaccio": "npm run unpublish-verdaccio && npm run build && cd dist && npm publish --registry http://localhost:4873",
     "publish-yalc": "npm run build && cd dist && yalc publish --push",
     "watch": "npm run node esbuild-watch.js && npm run build:esm-types && npm run build:cjs-types -- --watch",

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -134,7 +134,7 @@ export const useWalletConnectV2Login = ({
     () =>
       loginMethod === LoginMethodsEnum.walletconnectv2 ||
       getProviderType(providerRef.current) === LoginMethodsEnum.walletconnectv2,
-    [loginMethod, providerRef.current]
+    [loginMethod]
   );
 
   const handleOnLogout = () => {

--- a/src/hooks/login/useWalletConnectV2Login.ts
+++ b/src/hooks/login/useWalletConnectV2Login.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useGetAccountProvider } from 'hooks/account';
 import { useGetAccount } from 'hooks/account/useGetAccount';
 import { useUpdateEffect } from 'hooks/useUpdateEffect';
@@ -130,6 +130,13 @@ export const useWalletConnectV2Login = ({
   const loginFailed = Boolean(error);
   let token = tokenToSign;
 
+  const isWalletConnectV2Login = useCallback(
+    () =>
+      loginMethod === LoginMethodsEnum.walletconnectv2 ||
+      getProviderType(providerRef.current) === LoginMethodsEnum.walletconnectv2,
+    [loginMethod, providerRef.current]
+  );
+
   const handleOnLogout = () => {
     logout(logoutRoute);
   };
@@ -192,9 +199,7 @@ export const useWalletConnectV2Login = ({
   };
 
   const cancelLogin = async () => {
-    const providerType = getProviderType(providerRef.current);
-
-    if (providerType !== LoginMethodsEnum.walletconnectv2) {
+    if (!isWalletConnectV2Login()) {
       return;
     }
 
@@ -227,11 +232,7 @@ export const useWalletConnectV2Login = ({
     }
 
     try {
-      const providerType = providerRef.current
-        ? getProviderType(providerRef.current)
-        : false;
-
-      if (providerType !== LoginMethodsEnum.walletconnectv2) {
+      if (!isWalletConnectV2Login()) {
         // Prevent redirecting to wallet login hook
         await initiateLogin();
 
@@ -297,14 +298,9 @@ export const useWalletConnectV2Login = ({
   async function initiateLogin(loginProvider = true) {
     const isLoggedIn = getIsLoggedIn();
 
-    if (isLoggedIn) {
-      console.warn('Already logged in. Skipping wallet connect v2 login');
-      return;
-    }
-
     clearInitiatedLogins();
 
-    if (loginProvider) {
+    if (loginProvider && !isLoggedIn) {
       dispatch(setAddress(emptyAccount.address));
       dispatch(setAccount(emptyAccount));
     }
@@ -324,11 +320,9 @@ export const useWalletConnectV2Login = ({
     }
 
     const cannotLogin = mounted.current === false && !isLoggedIn;
-    const isWalletConnectProvider =
-      getProviderType(providerRef.current) === LoginMethodsEnum.walletconnectv2;
 
     const isInitialized =
-      providerRef.current?.isInitialized?.() && isWalletConnectProvider;
+      providerRef.current?.isInitialized?.() && isWalletConnectV2Login();
 
     if (isInitialisingRef.current || cannotLogin || isInitialized) {
       return;
@@ -423,11 +417,7 @@ export const useWalletConnectV2Login = ({
 
       token = validatedToken2;
 
-      const providerType = providerRef.current
-        ? getProviderType(providerRef.current)
-        : false;
-
-      if (providerType !== LoginMethodsEnum.walletconnectv2) {
+      if (!isWalletConnectV2Login()) {
         // Prevent redirecting to wallet login hook
         setIsLoading(true);
         await initiateLogin();
@@ -471,8 +461,7 @@ export const useWalletConnectV2Login = ({
 
     // Check if a new session has been created is already connected
     const isConnected =
-      Boolean(sessionProvider.session) ||
-      loginMethod === LoginMethodsEnum.walletconnectv2;
+      Boolean(sessionProvider.session) || isWalletConnectV2Login();
 
     // Set new provider only if account is logged in and if walletConnect session is available
     if (isConnected && isLoggedIn) {


### PR DESCRIPTION
### Issue
Unable to sign transactions on web wallet with walletconnect provider. Redirected to walletUrl sign hook

### Root cause
`initiateLogin` is required even when logged in

### Fix
- Made a helper to check if logged in as wallet connect. This helper checks both `loginMethod` and `providerRef.current`. Previously, providerRef.current shown `wallet` when `loginMethod` showed `walletconnectv2`.
- Skip clearing address and account from store if logged in `initiateLogin`

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [x] Unit tests
