### PR TITLE
5.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[5.6.21](https://github.com/multiversx/mx-sdk-dapp/pull/1728)] - 2026-03-11
+
+- [Use websocket transport as default on websocket init](https://github.com/multiversx/mx-sdk-dapp/pull/1727)
+
 ## [[5.6.20](https://github.com/multiversx/mx-sdk-dapp/pull/1726)] - 2026-03-10
 
 - [Added missing option to skip guardian checks in signTransactions function](https://github.com/multiversx/mx-sdk-dapp/pull/1726)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "5.6.19",
+  "version": "5.6.20-alpha.0",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "5.6.20",
+  "version": "5.6.21",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "MIT",

--- a/src/methods/initApp/websocket/initializeWebsocketConnection.ts
+++ b/src/methods/initApp/websocket/initializeWebsocketConnection.ts
@@ -106,7 +106,8 @@ export async function initializeWebsocketConnection(address: string) {
       reconnectionAttempts: RECONNECTION_ATTEMPTS,
       reconnectionDelay: RETRY_INTERVAL,
       timeout: TIMEOUT,
-      query: { address }
+      query: { address },
+      transports: ['websocket']
     });
 
     websocketConnection.instance.onAny(handleMessageReceived);

--- a/src/methods/initApp/websocket/tests/initializeWebsocketConnection.test.ts
+++ b/src/methods/initApp/websocket/tests/initializeWebsocketConnection.test.ts
@@ -73,7 +73,8 @@ describe('initializeWebsocketConnection tests', () => {
       reconnectionAttempts: 3,
       reconnectionDelay: 500,
       timeout: 3000,
-      query: { address: account.address }
+      query: { address: account.address },
+      transports: ['websocket']
     });
     expect(mockSocketInstance.onAny).toHaveBeenCalled();
     expect(mockSocketInstance.on).toHaveBeenCalledTimes(4);


### PR DESCRIPTION
### Issue/Feature

- Use websocket transport as default on websocket init

### Reproduce

Issue exists on version `2.` of sdk-dapp.

### Root cause

### Fix

### Additional changes

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [ ] No
- [x] Yes

### Testing

- [x] User testing
- [ ] Unit tests
