### PR TITLE
5.6.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [[5.6.22](https://github.com/multiversx/mx-sdk-dapp/pull/1729)] - 2026-03-17
+
+- [Fixed account balance does not update in the UI after receiving an incoming transaction via WebSocket.
+](https://github.com/multiversx/mx-sdk-dapp/pull/1729)
+
 ## [[5.6.21](https://github.com/multiversx/mx-sdk-dapp/pull/1728)] - 2026-03-11
 
 - [Use websocket transport as default on websocket init](https://github.com/multiversx/mx-sdk-dapp/pull/1727)

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "protobufjs": "^7.2.6"
   },
   "optionalDependencies": {
-    "@multiversx/sdk-dapp-ui": ">=0.1.23 <0.2.0"
+    "@multiversx/sdk-dapp-ui": ">=0.1.24 <0.2.0"
   },
   "resolutions": {
     "strip-ansi": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp",
-  "version": "5.6.21",
+  "version": "5.6.22",
   "description": "A library to hold the main logic for a dapp on the MultiversX blockchain",
   "author": "MultiversX",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         version: 8.15.0(eslint@9.15.0)(typescript@5.4.5)
     optionalDependencies:
       '@multiversx/sdk-dapp-ui':
-        specifier: '>=0.1.23 <0.2.0'
-        version: 0.1.23(@types/react@18.2.0)(react-dom@19.2.4(react@18.2.0))(react@18.2.0)(vue@3.5.29(typescript@5.4.5))
+        specifier: '>=0.1.24 <0.2.0'
+        version: 0.1.24(@types/react@18.2.0)(react-dom@19.2.4(react@18.2.0))(react@18.2.0)(vue@3.5.29(typescript@5.4.5))
 
 packages:
 
@@ -795,8 +795,8 @@ packages:
       bignumber.js: ^9.0.1
       protobufjs: ^7.2.6
 
-  '@multiversx/sdk-dapp-ui@0.1.23':
-    resolution: {integrity: sha512-nuDT48KHFQlOXLMjxlVVb7JEHNrW1qQYJ32rjS1ZWHDsfB/2EUn9FpdX/jr1LwNiKw8XpIaulvUjLJYguzStDg==}
+  '@multiversx/sdk-dapp-ui@0.1.24':
+    resolution: {integrity: sha512-p2Dnqh9CMmlYxSwH4ks+qjqsvzQ6ak8CEIZxAJ+Xj6tYiB8r4sgqamPDkSLsxn9114nxud7bkdw2mvJ+kepRLQ==}
     engines: {node: '>=20.19.0'}
 
   '@multiversx/sdk-dapp-utils@3.0.2':
@@ -5194,7 +5194,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@multiversx/sdk-dapp-ui@0.1.23(@types/react@18.2.0)(react-dom@19.2.4(react@18.2.0))(react@18.2.0)(vue@3.5.29(typescript@5.4.5))':
+  '@multiversx/sdk-dapp-ui@0.1.24(@types/react@18.2.0)(react-dom@19.2.4(react@18.2.0))(react@18.2.0)(vue@3.5.29(typescript@5.4.5))':
     dependencies:
       '@stencil/core': 4.38.1
       '@stencil/react-output-target': 1.2.0(@stencil/core@4.38.1)(@types/react@18.2.0)(react-dom@19.2.4(react@18.2.0))(react@18.2.0)

--- a/src/methods/trackTransactions/tests/trackTransactions.test.ts
+++ b/src/methods/trackTransactions/tests/trackTransactions.test.ts
@@ -1,8 +1,11 @@
 import { subscriptions } from 'constants/storage.constants';
 import { WebsocketConnectionStatusEnum } from 'constants/websocket.constants';
+import { getIsLoggedIn } from 'methods/account/getIsLoggedIn';
+import { pendingTransactionsSessionsSelector } from 'store/selectors/transactionsSelector';
 import { websocketEventSelector } from 'store/selectors/accountSelectors';
 import { getStore } from 'store/store';
 import { SubscriptionsEnum } from 'types/subscriptions.type';
+import { refreshAccount } from 'utils/account/refreshAccount';
 import { checkTransactionStatus } from '../helpers/checkTransactionStatus';
 import { getPollingInterval } from '../helpers/getPollingInterval';
 import { trackTransactions } from '../trackTransactions';
@@ -10,12 +13,25 @@ import { trackTransactions } from '../trackTransactions';
 // Mock all dependencies
 jest.mock('store/store');
 jest.mock('store/selectors/accountSelectors');
+jest.mock('store/selectors/transactionsSelector');
+jest.mock('methods/account/getIsLoggedIn');
+jest.mock('utils/account/refreshAccount');
 jest.mock('../helpers/checkTransactionStatus');
 jest.mock('../helpers/getPollingInterval');
 
 const mockGetStore = getStore as jest.MockedFunction<typeof getStore>;
 const mockWebsocketEventSelector =
   websocketEventSelector as jest.MockedFunction<typeof websocketEventSelector>;
+const mockPendingTransactionsSessionsSelector =
+  pendingTransactionsSessionsSelector as jest.MockedFunction<
+    typeof pendingTransactionsSessionsSelector
+  >;
+const mockGetIsLoggedIn = getIsLoggedIn as jest.MockedFunction<
+  typeof getIsLoggedIn
+>;
+const mockRefreshAccount = refreshAccount as jest.MockedFunction<
+  typeof refreshAccount
+>;
 const mockCheckTransactionStatus =
   checkTransactionStatus as jest.MockedFunction<typeof checkTransactionStatus>;
 const mockGetPollingInterval = getPollingInterval as jest.MockedFunction<
@@ -62,6 +78,9 @@ describe('trackTransactions', () => {
       timestamp: 1234567890,
       message: 'test-message'
     });
+    mockPendingTransactionsSessionsSelector.mockReturnValue({});
+    mockGetIsLoggedIn.mockReturnValue(false);
+    mockRefreshAccount.mockResolvedValue(undefined);
     mockCheckTransactionStatus.mockResolvedValue(undefined);
   });
 

--- a/src/methods/trackTransactions/trackTransactions.ts
+++ b/src/methods/trackTransactions/trackTransactions.ts
@@ -1,8 +1,11 @@
 import { subscriptions } from 'constants/storage.constants';
 import { WebsocketConnectionStatusEnum } from 'constants/websocket.constants';
+import { getIsLoggedIn } from 'methods/account/getIsLoggedIn';
+import { pendingTransactionsSessionsSelector } from 'store/selectors/transactionsSelector';
 import { websocketEventSelector } from 'store/selectors/accountSelectors';
 import { getStore } from 'store/store';
 import { SubscriptionsEnum } from 'types/subscriptions.type';
+import { refreshAccount } from 'utils/account/refreshAccount';
 import { checkTransactionStatus } from './helpers/checkTransactionStatus';
 import { getPollingInterval } from './helpers/getPollingInterval';
 
@@ -55,6 +58,15 @@ export async function trackTransactions(): Promise<{
         ) {
           timestamp = websocketEvent.timestamp;
           recheckStatus();
+
+          const hasPendingSessions =
+            Object.keys(
+              pendingTransactionsSessionsSelector(store.getState())
+            ).length > 0;
+
+          if (!hasPendingSessions && getIsLoggedIn()) {
+            refreshAccount();
+          }
         }
       }
     );


### PR DESCRIPTION
### Issue

Account balance does not update in the UI after receiving an incoming transaction via WebSocket.

### Reproduce

Issue exists on sdk-dapp v5 (Zustand store).

1. Log in to dapp with any account
2. Have a second account send EGLD to the logged-in account
3. Observe that the `transactionCompleted` WebSocket event fires and the `TransactionReceivedToast` appears — but the account balance displayed on the dashboard remains stale

### Root cause

`trackTransactions` → `recheckStatus` → `checkTransactionStatus` exits early when there are no pending outgoing transaction sessions (`entries.length === 0`). This is always the case for incoming transactions since the wallet has no session tracking them.

For outgoing transactions, `checkBatch` calls `refreshAccount()` once the batch completes, which updates the Zustand account store. For incoming transactions, nothing triggered `refreshAccount()`, leaving the balance stale until a page refresh.

In sdk-dapp v4 (Redux-based) this was handled internally by the store. In v5 (Zustand), `setAccount` must be called explicitly via `refreshAccount()`.

### Fix

In `setupWebSocketTracking` inside `trackTransactions.ts`, after calling `recheckStatus()`, check whether there are no pending outgoing sessions. If so (incoming transaction case) and the user is logged in, call `refreshAccount()`.

**File:** `src/methods/trackTransactions/trackTransactions.ts`

```ts
const hasPendingSessions =
  Object.keys(
    pendingTransactionsSessionsSelector(store.getState())
  ).length > 0;

if (!hasPendingSessions && getIsLoggedIn()) {
  refreshAccount();
}
```

This is intentionally placed inside `setupWebSocketTracking` (WS event subscriber only) rather than in `checkTransactionStatus` or `recheckStatus`, to avoid triggering unnecessary API calls on:
- Initial `recheckStatus()` call at startup (line 81)
- Periodic polling interval (when WS is unavailable)

### Additional changes

None.

### Contains breaking changes

- [x] No
- [ ] Yes

### Updated CHANGELOG

- [x] No
- [ ] Yes

### Testing

- [x] User testing
- [ ] Unit tests
